### PR TITLE
Fix format for the dates before epoch time

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -307,9 +307,9 @@ function erp_format_date( $date, $format = false ) {
         $format = erp_get_option( 'date_format', 'erp_settings_general', 'd-m-Y' );
     }
 
-    $date_str = strtotime( $date );
+    $time = strtotime( $date );
 
-    return date_i18n( $format, strtotime( $date ) );
+    return ( $time >= 0 ) ? date_i18n( $format, $time ) : "—";
 }
 
 /**


### PR DESCRIPTION
If given date is before 1970-01-01 or null then it will show a dash from now on.