### PR TITLE
Employee tabs URL changed to erp-my-profile - Tried to fix #451

### DIFF
--- a/modules/hrm/includes/functions-employee.php
+++ b/modules/hrm/includes/functions-employee.php
@@ -898,7 +898,13 @@ function erp_hr_url_single_employee( $employee_id, $tab = null ) {
         $tab = '&tab=' . $tab;
     }
 
-    $url = admin_url( 'admin.php?page=erp-hr-employee&action=view&id=' . $employee_id . $tab );
+    $user = wp_get_current_user();
+    
+    if (in_array( 'employee' , (array) $user->roles)) {
+        $url = admin_url( 'admin.php?page=erp-hr-my-profile&action=view&id=' . $employee_id . $tab );
+    } else {
+        $url = admin_url( 'admin.php?page=erp-hr-employee&action=view&id=' . $employee_id . $tab );
+    }
 
     return apply_filters( 'erp_hr_url_single_employee', $url, $employee_id );
 }


### PR DESCRIPTION
Tried to fix #451 
Added the code to check if the current logged in user role is **Employee**.
If yes, then the URL will contain page=erp-my-profile.
If not, then the URL will contain page=erp-hr-employee.
Please modify the code if it feels sloppy, would like to see if there's a better way to do this.