### PR TITLE
Fix secuirty issue make wp user

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3302,7 +3302,11 @@ function erp_crm_make_wp_user( $customer_id, $args = [] ) {
     $people = (array) erp_get_people_by( 'id', intval( $customer_id ) );
 
     $email = ! empty( $people['email'] ) ? $people['email'] : $args['email'];
-    $role = ! empty( $args['role'] ) ? $args['role'] : 'subscriber';
+    if ( current_user_can( 'administrator' ) ) {
+    	$role = ! empty( $args['role'] ) ? $args['role'] : 'subscriber';
+    } else {
+    	$role = 'subscriber';
+    }
     $type = ! empty( $args['type'] ) ? $args['type'] : '';
 
     if ( empty( $email ) ) {

--- a/modules/crm/views/js-templates/make-wp-user.php
+++ b/modules/crm/views/js-templates/make-wp-user.php
@@ -7,9 +7,13 @@
     <# } #>
     <div class="row">
         <label for="wp-user-role"><?php _e( 'Role', 'erp' ) ?></label>
-        <select name="customer_role" id="wp-user-role">
-            <?php wp_dropdown_roles( get_option('default_role') ); ?>
-        </select>
+        <?php if ( current_user_can( 'administrator' ) ) : ?>
+            <select name="customer_role" id="wp-user-role">
+                <?php wp_dropdown_roles( get_option( 'default_role' ) ); ?>
+            </select>
+        <?php else : ?>
+        	<input type="text" name="customer_role" id="wp-user-role" value="<?php echo get_option( 'default_role' ); ?>" readonly>
+        <?php endif;  ?>
     </div>
 
     <div class="row">


### PR DESCRIPTION
Managers that can create wp user from contact can assign to him any role including administrator which has higher capabilities that the manager who created the user. Could be used to hack the WordPress instance.