### PR TITLE
Fix: create contact from created user conflicts

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3061,11 +3061,20 @@ function erp_create_contact_from_created_user( $user_id ) {
     if ( empty ( $matched_roles ) ) {
         return;
     }
+    
+    $people = erp_get_people_by( 'email', $user->user_email );
+    if ( false !== $people ) {
+        return;
+    }
 
     $data = [];
 
-    $data['type']    = 'contact';
-    $data['user_id'] = $user_id;
+    $data['type']       = 'contact';
+    $data['user_id']    = $user_id;
+    $data['first_name'] = $user->first_name;
+    $data['last_name']  = $user->last_name;
+    $data['email']      = $user->user_email;
+    $data['website']    = $user->user_url;
 
     $contact_id    = erp_insert_people( $data );
     $contact_owner = erp_get_option( 'contact_owner', 'erp_settings_erp-crm_contacts', null );


### PR DESCRIPTION
ERP Settings >> CRM if auto import is enabled and we are making wp user from contact the newly created user will recreate another contact in addition to original one as "erp_crm_make_wp_user" function is calling "wp_insert_user" function which do "user_register" action which is the hook of "erp_create_contact_from_created_user" function. and so a new contact is created.
Another conflict is that the "erp_create_contact_from_created_user" function does not pass (first_name, last_name, email) to "erp_insert_people" function so the created contact data is empty and it also affects the creation of new users in WordPress.