### PR TITLE
Remove contact subscriber hash

### DIFF
--- a/includes/admin/class-ajax.php
+++ b/includes/admin/class-ajax.php
@@ -441,15 +441,12 @@ class Ajax {
                 $existing_data = \WeDevs\ERP\CRM\Models\ContactSubscriber::where( [ 'group_id' => $contact_group, 'user_id' => $people->id ] )->first();
 
                 if ( empty( $existing_data ) ) {
-                    $hash = sha1( microtime() . 'erp-subscription-form' . $contact_group . $people->id );
-
                     erp_crm_create_new_contact_subscriber([
                         'group_id'          => $contact_group,
                         'user_id'           => $people->id,
                         'status'            => 'subscribe',
                         'subscribe_at'      => current_time( 'mysql' ),
-                        'unsubscribe_at'    => null,
-                        'hash'              => $hash
+                        'unsubscribe_at'    => null
                     ]);
                 }
             }

--- a/includes/class-install.php
+++ b/includes/class-install.php
@@ -621,7 +621,6 @@ Company'
               `status` varchar(25) DEFAULT NULL,
               `subscribe_at` datetime DEFAULT NULL,
               `unsubscribe_at` datetime DEFAULT NULL,
-              `hash` VARCHAR(40) NULL DEFAULT NULL,
               PRIMARY KEY (`id`),
               UNIQUE KEY `user_group` (`user_id`,`group_id`)
             ) $collate;",

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1737,15 +1737,12 @@ function erp_process_import_export() {
                             $existing_data = \WeDevs\ERP\CRM\Models\ContactSubscriber::where( [ 'group_id' => $contact_group, 'user_id' => $people->id ] )->first();
 
                             if ( empty( $existing_data ) ) {
-                                $hash = sha1( microtime() . 'erp-subscription-form' . $contact_group . $people->id );
-
                                 erp_crm_create_new_contact_subscriber([
                                     'group_id'          => $contact_group,
                                     'user_id'           => $people->id,
                                     'status'            => 'subscribe',
                                     'subscribe_at'      => current_time( 'mysql' ),
-                                    'unsubscribe_at'    => null,
-                                    'hash'              => $hash
+                                    'unsubscribe_at'    => null
                                 ]);
                             }
                         }

--- a/modules/crm/includes/class-subscription.php
+++ b/modules/crm/includes/class-subscription.php
@@ -393,8 +393,7 @@ class Subscription {
                 $subs_args = [
                     'group_id' => $group_id,
                     'user_id'  => $contact_id,
-                    'status'   => $status,
-                    'hash'     => $hash
+                    'status'   => $status
                 ];
 
                 $subscribed_groups[] = erp_crm_create_new_contact_subscriber( $subs_args );

--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -1391,8 +1391,7 @@ function erp_crm_edit_contact_subscriber( $groups, $user_id ) {
         foreach ( $new_group as $new_group_key => $new_group_id ) {
             $data = [
                 'user_id'  => $user_id,
-                'group_id' => $new_group_id,
-                'hash'     => sha1( microtime() . 'erp-subscription' . $new_group_id . $user_id )
+                'group_id' => $new_group_id
             ];
 
             erp_crm_create_new_contact_subscriber( $data );

--- a/modules/crm/includes/models/contact-group.php
+++ b/modules/crm/includes/models/contact-group.php
@@ -35,7 +35,7 @@ class ContactGroup extends Model {
         $group_tbl  = $prefix . $this->table;
         $subs_tbl   = $prefix . 'erp_crm_contact_subscriber';
 
-        $query->select( $group_tbl . '.id', $group_tbl . '.name', $group_tbl . '.private', $subs_tbl . '.user_id', $subs_tbl . '.status', $subs_tbl . '.subscribe_at', $subs_tbl . '.unsubscribe_at', $subs_tbl . '.hash' )
+        $query->select( $group_tbl . '.id', $group_tbl . '.name', $group_tbl . '.private', $subs_tbl . '.user_id', $subs_tbl . '.status', $subs_tbl . '.subscribe_at', $subs_tbl . '.unsubscribe_at' )
               ->leftJoin( $subs_tbl, $group_tbl . '.id', '=', $subs_tbl . '.group_id' )
               ->where( $subs_tbl . '.user_id', $people_id );
 

--- a/modules/crm/includes/models/contact-subscriber.php
+++ b/modules/crm/includes/models/contact-subscriber.php
@@ -11,7 +11,7 @@ use WeDevs\ERP\Framework\Model;
 class ContactSubscriber extends Model {
     protected $table = 'erp_crm_contact_subscriber';
 
-    protected $fillable = [ 'user_id', 'group_id', 'status', 'subscribe_at', 'unsubscribe_at', 'hash' ];
+    protected $fillable = [ 'user_id', 'group_id', 'status', 'subscribe_at', 'unsubscribe_at' ];
 
     public $timestamps = false;
 


### PR DESCRIPTION
Fix: #500 as installs from v1.1.17 to v1.2.3 has no 'Hash' colmun in
'erp_crm_contact_subscriber' table which generates error, and as from
v1.2.2 'Hash' colmun is not needed anymore and replaced by people meta
this PR to remove traces of hash.