### PR TITLE
Fixes #544 When Accounting module is deactivated, gives a fatal error.

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3084,7 +3084,9 @@ function erp_create_contact_from_created_user( $user_id ) {
     $contact_id            = erp_insert_people( $data );
 	
     // create accounting customer from wp user
-    erp_ac_customer_create_from_crm( [], $contact_id, $data );
+    if ( erp_is_module_active( 'accounting' ) ) {
+        erp_ac_customer_create_from_crm( [], $contact_id, $data );
+    }
 
     return;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Add module activation check before calling the function.

#### Related issue(s):
#544 