### PR TITLE
Fixes #544 When Accounting module is deactivated, gives a fatal error.

### DIFF
--- a/modules/accounting/includes/actions-filters.php
+++ b/modules/accounting/includes/actions-filters.php
@@ -8,6 +8,7 @@ add_action( 'erp_hr_permission_management', 'erp_ac_permission_management_field'
 
 // accounting customer auto create
 add_action( 'erp_crm_save_contact_data', 'erp_ac_customer_create_from_crm', 10, 3 );
+add_action( 'erp_crm_contact_created', 'erp_ac_customer_auto_create_from_crm', 10, 2 );
 
 // Read Only Invoice template
 add_action( 'template_redirect', 'erp_ac_readonly_invoice_template' );

--- a/modules/accounting/includes/functions.php
+++ b/modules/accounting/includes/functions.php
@@ -741,3 +741,17 @@ function erp_ac_customer_create_from_crm( $customer, $customer_id, $data ) {
     erp_convert_to_people( $data );
 }
 
+/**
+ * Accounting customer auto create from crm
+ *
+ * @since  1.2.8
+ * 
+ * @param  int    $contact_id
+ * @param  object $data
+ * 
+ * @return void
+ */
+function erp_ac_customer_auto_create_from_crm( $contact_id, $data ) {
+    return erp_ac_customer_create_from_crm( [],  $contact_id, $data );
+}
+

--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3041,7 +3041,7 @@ function erp_user_bulk_actions_notices() {
  * Create contact from created user.
  *
  * @since 1.0
- * @since 1.2.7 create accounting customer from wp user
+ * @since 1.2.8 erp_crm_contact_created action
  *
  * @param  int $user_id
  *
@@ -3082,11 +3082,8 @@ function erp_create_contact_from_created_user( $user_id ) {
     $data['contact_owner'] = $contact_owner;
     $data['life_stage']    = $life_stage;
     $contact_id            = erp_insert_people( $data );
-	
-    // create accounting customer from wp user
-    if ( erp_is_module_active( 'accounting' ) ) {
-        erp_ac_customer_create_from_crm( [], $contact_id, $data );
-    }
+
+    do_action( 'erp_crm_contact_created', $contact_id, $data );
 
     return;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Fixed by adding an action hook.

#### Related issue(s):
#544 