### PR TITLE
Bug Fix for adding Companies to Customers.

### DIFF
--- a/modules/crm/includes/class-ajax.php
+++ b/modules/crm/includes/class-ajax.php
@@ -610,7 +610,7 @@ class Ajax_Handler {
 
         $found_crm_contact = [];
         $type              = ( count( $types ) > 1 ) ? $types : reset( $types );
-        $crm_contacts      = erp_get_peoples( [ 's' => $term, 'type' => 'contact' ] );
+        $crm_contacts      = erp_get_peoples( [ 's' => $term, 'type' => $type ] );
 
         if ( ! empty( $crm_contacts ) ) {
             foreach ( $crm_contacts as $user ) {


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Issue - Couldn’t add a company to a customer, was always returning all customers instead.

Fix - erp_get_peoples was always passing ‘contact’. $type was already being set correctly so switching out the args for erp_get_peoples to use that so it works correctly.

#### Related issue(s):
