### PR TITLE
Postal Code does not appear on a Customer's User Details tab

### DIFF
--- a/modules/accounting/includes/views/customer/user-details.php
+++ b/modules/accounting/includes/views/customer/user-details.php
@@ -16,6 +16,6 @@
     'address_2' => '',
     'city'      => $customer->city,
     'state'     => erp_get_state_name( $customer->country, $customer->state ),
-    'postcode'  => $customer->postcode,
+    'postcode'  => $customer->postal_code,
     'country'   => erp_get_country_name( $customer->country ),
 ]); ?>


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
postcode is not a valid column on the erp_peoples table. Use postal_code instead.

#### Related issue(s):
Postal Code does not appear on a Customer's User Details tab