### PR TITLE
A Payment Voucher's Total amount is not formatted as currency

### DIFF
--- a/modules/accounting/includes/views/expense/payment-voucher-single.php
+++ b/modules/accounting/includes/views/expense/payment-voucher-single.php
@@ -142,7 +142,7 @@ $taxinfo          = erp_ac_get_tax_info();
                             </tr>
                             <tr>
                                 <th><?php _e( 'Total', 'erp' ); ?></th>
-                                <td><?php echo $transaction->total; ?></td>
+                                <td><?php echo erp_ac_get_price( $transaction->total ); ?></td>
                             </tr>
                             <tr>
                                 <th><?php _e( 'Total Paid', 'erp' ); ?></th>


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Format the Total amount as currency.

#### Related issue(s):
A Payment Voucher's Total amount is not formatted as currency.