### PR TITLE
A Vendor text field on an Add Customer form is confusing

### DIFF
--- a/modules/accounting/includes/views/user-form-rows.php
+++ b/modules/accounting/includes/views/user-form-rows.php
@@ -74,7 +74,7 @@
     </li>
     <li class="erp-form-field row-company">
         <?php erp_html_form_input( array(
-            'label'       => __( 'Vendor', 'erp' ),
+            'label'       => __( 'Company', 'erp' ),
             'name'        => 'company',
             'id'          => 'company',
             'required'    => ( $item_type == 'vendor' ) ? true : false,


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Replace the text field label: Vendor with Company.

#### Related issue(s):
A Vendor text field on an Add Customer form is confusing.