### PR TITLE
Update functions.php

### DIFF
--- a/modules/hrm/includes/functions.php
+++ b/modules/hrm/includes/functions.php
@@ -59,7 +59,7 @@ function erp_hr_get_work_days_without_off_day( $start_date, $end_date ) {
     foreach ( $between_dates as $date ) {
 
         $key       = strtolower( date( 'D', strtotime( $date ) ) );
-        $is_holidy = ( $work_days[ $key ] === 0 ) ? true : false;
+        $is_holidy = ( $work_days[ $key ] == 0 ) ? true : false;
 
         if ( ! $is_holidy ) {
             $is_holidy = in_array( $date, $holiday_exist ) ? true : false;


### PR DESCRIPTION
Hi, I'm using your wp plugin and I've seen a mistake on this line. When is a weekend or holiday '$is_holidy' should be true, but your comparison return false. I think that is because the type of '$work_days[$key]' is not an integer like '0'. I changed it with a simple equal comparison and it worked ..

I hope that this help you.

Best regards!

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
