### PR TITLE
Update invoice.php

### DIFF
--- a/modules/accounting/includes/views/pdf/invoice.php
+++ b/modules/accounting/includes/views/pdf/invoice.php
@@ -81,7 +81,7 @@ foreach ( $transaction->items as $line ) {
 
 // Invoice add memo
 if ( $transaction->summary ) {
-    $invoice->set_memo( $transaction->summary );
+    $invoice->add_paragraph($transaction->summary );
 }
 
 // Subtotal and Total


### PR DESCRIPTION
Memo was not appear on the invoice issue solved  
set_memo this var is not exist in the pdf invoicer class .

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
