### PR TITLE
add filter for change/add fields on CRM contact form

### DIFF
--- a/modules/crm/includes/class-ajax.php
+++ b/modules/crm/includes/class-ajax.php
@@ -332,6 +332,8 @@ class Ajax_Handler {
             $this->send_error( __( 'Cotact does not exists.', 'erp' ) );
         }
 
+        $customer = apply_filters( 'erp_crm_ajax_customer_get', $customer );
+
         $this->send_success( $customer->to_array() );
     }
 


### PR DESCRIPTION
Changes proposed in this Pull Request:

**I propose add filter for data that return by AJAX on show CRM contact form.**

Related issue(s):

I was need change contact form, add some fields.

I can override form template:

```
add_filter( 'erp_crm_js_template_file_path', function( $file_path, $id ) {
	if ('erp-crm-new-contact' == $id) return get_template_directory() . '/erp/modules/crm/views/js-templates/new-customer.php';
	else return $file_path;
}, 10, 2);
```

I can save changed data on form sent:

```
add_action('erp_crm_save_contact_data', function( $customer, $customer_id, $data ) {
	update_user_meta( $customer_id, 'customer_friend', intval( $data['friend'] ));
	update_user_meta( $customer_id, 'customer_plan', intval( $data['plan'] ));
}, 10, 3);
```

But I can not see values for my new fields on form without this filter:

```
add_filter( 'erp_crm_ajax_customer_get', function( $customer ) {
	$customer->data->friend = intval( get_user_meta( $customer->data->id, 'customer_friend', TRUE));
	$customer->data->plan = intval(get_user_meta( $customer->data->id, 'customer_plan', TRUE));
	return $customer;
});
```

