### PR TITLE
fix issue: update contact owner by user_id

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3740,11 +3740,13 @@ function erp_crm_get_contact_owner( $contact_id ) {
  * @return WP_Error|void
  */
 function erp_crm_update_contact_owner( $contact_id, $owner_id ) {
-    $contact = new \WeDevs\ERP\CRM\Contact( $contact_id );
-
-    if ( empty( $contact ) ) {
+    $people = erp_get_people_by('user_id', $contact_id);
+    
+    if ( empty( $people ) ) {
         return new \WP_Error( 'no-erp-people', __( 'People not exists', 'erp' ) );
     }
+
+    $contact = new \WeDevs\ERP\CRM\Contact( $people->id );
 
     $contact->update_contact_owner( $owner_id );
 }


### PR DESCRIPTION
the function 'erp_crm_update_contact_owner' is passed two
parameters: contact_id, owner_id. the contact_id seems to refer to
the 'user_id' field in the wp_erp_peoples table, however, the function
implementation is populating the contact object with the 'id' field
of the wp_erp_peoples table.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

lookup contact by user_id, grab id field, use id field to construct the Contact object.

#### Related issue(s):

see issue #746 