### PR TITLE
the safiest way to find out when https is used

### DIFF
--- a/modules/accounting/accounting.php
+++ b/modules/accounting/accounting.php
@@ -277,7 +277,16 @@ class Accounting {
      * @return void
      */
     public function pdf_notice_message( $type ) {
-        $actual_link = esc_url( (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" );
+	$isSecure = false;
+	/*when using ISAPI with IIS, the value of $_SERVER['HTTPS'] will be off, if the request was not made through the HTTPS protocol*/
+	if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+    		$isSecure = true;
+	/*In he standard conditions [$_SERVER['HTTPS'] == 'on'] do not work on servers behind a load balancer (reverse proxy)*/
+	/*Load balancer may communicate with a web server using HTTP even if the request to the sever is HTTPS, so HTTP_X_FORWARDED_PROTO is a de facto standard for this scope*/
+	}elseif ( !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on' ) {
+	    $isSecure = true;
+	}
+        $actual_link = esc_url( ($isSecure ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" );
         $sign = empty( $_GET ) ? '?' : '&';
 
         echo '<div class="updated notice is-dismissible notice-pdf"><p>';


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
I change the way the php identifying WHEN https is used by EACH server!

In the php manual (http://php.net/reserved.variables.server )we see that it says that $_SERVER['HTTPS'] set to a non-empty value if the script was queried through the HTTPS protocol, but when using ISAPI with IIS, the value will be off if the request was not made through the HTTPS protocol.

In addiction, with more research (https://stackoverflow.com/questions/1175096/how-to-find-out-if-youre-using-https-without-serverhttps/2886224), I found out that a reverse proxy (load balancer) not understand all the time the variable $_SERVER['HTTPS'], so in this case we must use $_SERVER['HTTP_X_FORWARDED_PROTO'] variable. This operates good in load balancers,  in AWS Elastic
and in CloudFlare. More you can see in the link  above!

#### Related issue(s):
https, ssl, servers