### PR TITLE
Add argument to action `erp_hr_employee_update`

### DIFF
--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -426,7 +426,7 @@ class Employee {
             return $this;
         }
 
-        do_action( 'erp_hr_employee_update', $this->user_id, wp_parse_args( $this->data, $this->changes ) );
+        do_action( 'erp_hr_employee_update', $this->user_id, wp_parse_args( $this->data, $this->changes ), $this->changes );
 
         if ( ! empty( $this->changes['work'] ) ) {
             $this->erp_user->update( $this->changes['work'] );


### PR DESCRIPTION
Allows hooks to access new values during update (#777)

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

Add `$this->changes` as separate argument to `erp_hr_employee_update` action so hooks have reliable access to new data on employee update.

#### Related issue(s):
#777 