### PR TITLE
Unit Price needs to be able to accept decimal values.

### DIFF
--- a/modules/accounting/assets/src/admin/components/purchase/PurchaseRow.vue
+++ b/modules/accounting/assets/src/admin/components/purchase/PurchaseRow.vue
@@ -13,6 +13,7 @@
         <td class="col--uni_price" data-colname="Unit Price">
             <input min="0" type="number" v-model="line.unitPrice"
                 @keyup="calculateAmount"
+                step="0.01"
                 class="wperp-form-field text-right" :required="line.selectedProduct ? true : false">
         </td>
         <td class="col--amount" data-colname="Amount">


### PR DESCRIPTION
..._erp_acct_purchase_details.price is decimal(10,2) in the database.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
If step is not set to 0.01, the unit price field can only accept integer values.

#### Related issue(s):
#867 