### PR TITLE
Fixed - Can't send SMS if all employees are selected

### DIFF
--- a/modules/hrm/includes/class-announcement.php
+++ b/modules/hrm/includes/class-announcement.php
@@ -441,7 +441,7 @@ class Announcement {
 		// Assign / Send announcements to the selected group
         erp_hr_assign_announcements_to_employees( $post_id, $type, $selected );
 
-        do_action( 'hr_annoucement_save', $post_id, $selected );
+        //do_action( 'hr_annoucement_save', $post_id, $selected );
     }
 
 }

--- a/modules/hrm/includes/functions-announcement.php
+++ b/modules/hrm/includes/functions-announcement.php
@@ -56,6 +56,8 @@ function erp_hr_assign_announcements_to_employees( $post_id, $type, $selected = 
         }
     }
 
+    do_action( 'hr_annoucement_save', $post_id, $selected );
+
     $announces_object = \WeDevs\ERP\HRM\Models\Announcement::where( 'post_id', $post_id )->whereIn( 'user_id', $selected );
 
     $announcements      = $announces_object->get();


### PR DESCRIPTION
https://github.com/wp-erp/wp-erp/issues/905