### PR TITLE
Squash Integration

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,0 +1,9 @@
+deployments:
+  WP-ERP:
+    filename:
+      ./docker-compose-wizard.yml
+    vm_size: 2GB
+  WP-ERP Pre-configured (squash/squashpwd):
+    filename:
+      ./docker-compose.yml
+    vm_size: 2GB

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM wordpress
+
+COPY . /usr/src/wordpress/wp-content/plugins/wp-erp
+
+RUN apt-get update && apt-get install -y unzip git sudo && \
+    cd /usr/src/wordpress/wp-content/plugins/ && \
+    sudo chown -R www-data wp-erp && \
+    cd /usr/src/wordpress/wp-content/plugins/wp-erp && \
+    curl --output composer-setup.php https://getcomposer.org/installer && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm -f composer-setup.php && \
+    mkdir /var/www/.composer && chown www-data:www-data /var/www/.composer && \
+    sudo -u www-data composer install && \
+    sudo -u www-data composer dump-autoload -o && \
+    curl --output /usr/local/sbin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x /usr/local/sbin/wp
+
+COPY apache2_wp-erp.sh /usr/local/bin/apache2_wp-erp.sh
+CMD ["apache2_wp-erp.sh"]

--- a/Dockerfile.wizard
+++ b/Dockerfile.wizard
@@ -1,0 +1,16 @@
+FROM wordpress
+
+COPY . /usr/src/wordpress/wp-content/plugins/wp-erp
+
+RUN set -x && \
+    apt-get update && apt-get install -y unzip git sudo && \
+    cd /usr/src/wordpress/wp-content/plugins/ && \
+    sudo chown -R www-data wp-erp && \
+    cd /usr/src/wordpress/wp-content/plugins/wp-erp && \
+    # rm -rf .git && rm -rf .github &&\
+    curl --output composer-setup.php https://getcomposer.org/installer && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm -f composer-setup.php && \
+    mkdir /var/www/.composer && chown www-data:www-data /var/www/.composer && \
+    sudo -u www-data composer install && \
+    sudo -u www-data composer dump-autoload -o

--- a/apache2_wp-erp.sh
+++ b/apache2_wp-erp.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ ! $(sudo -u www-data wp core is-installed) ]]
+then
+    sudo -u www-data wp core install --url=${SQUASH_DOMAIN} --title="squash.io test site" --admin_name=${WORDPRESS_ADMIN_USER} --admin_password=${WORDPRESS_ADMIN_PASSWORD} --admin_email=test@example.com
+    sudo -u www-data wp plugin activate wp-erp
+fi
+apache2-foreground

--- a/docker-compose-wizard.yml
+++ b/docker-compose-wizard.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+
+services:
+  wp-erp:
+    restart: always
+    build:
+      context: ./
+      dockerfile: Dockerfile.wizard
+    ports:
+      - 80:80
+    environment:
+      WORDPRESS_DB_USER: wp-erp-user
+      WORDPRESS_DB_PASSWORD: wp-erp-pass
+      WORDPRESS_DB_NAME: wp-erp
+      WORDPRESS_DB_HOST: database.wp-erp
+    container_name: web.wp-erp
+
+  database:
+    image: mysql
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    environment:
+      MYSQL_DATABASE: wp-erp
+      MYSQL_USER: wp-erp-user
+      MYSQL_PASSWORD: wp-erp-pass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    container_name: database.wp-erp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.7'
+
+services:
+
+  wp-erp:
+    restart: always
+    build: .
+    ports:
+      - 80:80
+    environment:
+      WORDPRESS_DB_USER: wp-erp-user
+      WORDPRESS_DB_PASSWORD: wp-erp-pass
+      WORDPRESS_DB_NAME: wp-erp
+      WORDPRESS_DB_HOST: database.wp-erp
+      WORDPRESS_ADMIN_USER: squash
+      WORDPRESS_ADMIN_PASSWORD: squashpwd
+      SQUASH_DOMAIN: ${SQUASH_DOMAIN}
+    container_name: web.wp-erp
+    depends_on:
+      - database
+
+  database:
+    image: mysql
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    environment:
+      MYSQL_DATABASE: wp-erp
+      MYSQL_USER: wp-erp-user
+      MYSQL_PASSWORD: wp-erp-pass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    container_name: database.wp-erp


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a patch to integrate Squash.io with WP-ERP. I believe this is going to be handy to the project so any project maintainers and developers can quickly check the branch changes (including its full WordPress install) deployed on its own isolated VM.

Example of WP-ERP working with Squash: https://squash-integration-xj5lk.squash.io/

Admin area (credentials: squash/squashpwd): https://squash-integration-xj5lk.squash.io/wp-login.php

Squash is free for Open Source, maintainers just need to [signup here](https://www.squash.io/sign-up/) and reach out to the [support](https://www.squash.io/support/) through the chat window and we will enable a **forever free** Open Source account **with higher limits than our regular free account**. Once this is done, Squash will post a comment on each [Pull Request like this ](https://github.com/emiquelito/wp-erp/pull/3)- see screenshot:

![Screen Shot 2019-11-05 at 3 47 15 PM](https://user-images.githubusercontent.com/98694/68252757-8e34e100-ffe3-11e9-803b-681c4719432c.png)

Please note that in this PR we are using two pre-made URLs in this Squash comment.

* The first URL will trigger the WP wizard/install pages.
* The 2nd URL skips the wizard, automatically activates the WP-ERP plugin and adds a test user account with credentials: squash/squashpwd. This is to make it super easy for team members to review changes in their code straight in a fully working deployment.

#### Related issue(s):

None