### PR TITLE
added first_name and email as required fields to avoid duplicate entry

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3918,8 +3918,11 @@ kbd {
   height: 33px;
 }
 .erp-customer-form span.required {
-  margin: 10px 10px 0;
+  margin: 0px 10px 0;
   display: inline-block;
+}
+.erp-customer-form span.space-top {
+    margin-top: 10px;
 }
 .erp-customer-form input[type='number'] {
   height: 33px;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -3918,7 +3918,7 @@ kbd {
   height: 33px;
 }
 .erp-customer-form span.required {
-  margin: 0px 10px 0;
+  margin: 0 10px 0;
   display: inline-block;
 }
 .erp-customer-form span.space-top {

--- a/assets/less/admin/admin.less
+++ b/assets/less/admin/admin.less
@@ -2006,7 +2006,7 @@ code, kbd {
 
 .erp-customer-form {
     span.required {
-        margin: 0px 10px 0;
+        margin: 0 10px 0;
         display: inline-block;
     }
 

--- a/assets/less/admin/admin.less
+++ b/assets/less/admin/admin.less
@@ -2006,8 +2006,12 @@ code, kbd {
 
 .erp-customer-form {
     span.required {
-        margin: 10px 10px 0;
+        margin: 0px 10px 0;
         display: inline-block;
+    }
+
+    span.space-top {
+        margin-top: 10px;
     }
 
     input[type='number'] {

--- a/includes/functions-people.php
+++ b/includes/functions-people.php
@@ -507,16 +507,16 @@ function erp_insert_people( $args = array(), $return_object = false ) {
     if ( 'contact' == $people_type ) {
         if ( empty( $args['user_id'] ) ) {
             // Check if contact first name or email or phone provided or not
-            if ( empty( $args['first_name'] ) && empty( $args['phone'] ) && empty( $args['email'] ) ) {
-                return new WP_Error( 'no-basic-data', __( 'You must need to fillup either first name or phone or email', 'erp' ) );
+            if ( empty( $args['first_name'] ) || empty( $args['email'] ) ) {
+                return new WP_Error( 'no-basic-data', __( 'You must need to fill up either first name or phone or email', 'erp' ) );
             }
         }
     }
 
     // Check if company name provide or not
     if ( 'company' == $people_type ) {
-        if ( empty( $args['company'] ) && empty( $args['phone'] ) && empty( $args['email'] ) ) {
-            return new WP_Error( 'no-company', __( 'You must need to fillup either Company name or email or phone', 'erp' ) );
+        if ( empty( $args['company'] ) || empty( $args['email'] ) ) {
+            return new WP_Error( 'no-company', __( 'You must need to fill up either Company name or email or phone', 'erp' ) );
         }
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1208,6 +1208,7 @@ function erp_get_import_export_fields() {
         'contact'  => [
             'required_fields' => [
                 'first_name',
+                'email'
             ],
             'fields'          => [
                 'first_name',

--- a/modules/crm/views/js-templates/new-customer.php
+++ b/modules/crm/views/js-templates/new-customer.php
@@ -33,11 +33,11 @@
             <div class="col-4 right-column">
                 <div class="erp-crm-modal-right">
                 <# if ( _.contains( data.types, 'company' ) ) { #>
-                    <span class="required">* <?php _e( 'Company name or email or phone is required', 'erp' ) ?></span>
+                    <span class="required space-top">* <?php _e( 'Company name and email are required', 'erp' ) ?></span>
 
                     <?php do_action( 'erp_crm_company_form_top' ); ?>
                 <# } else { #>
-                    <span class="required">* <?php _e( 'First name or email or phone is required', 'erp' ); ?></span>
+                    <span class="required space-top">* <?php _e( 'First name and email are required', 'erp' ); ?></span>
 
                     <?php $custom_attr_length = apply_filters( 'erp_crm_custom_attr_length', 30 ); ?>
 
@@ -55,7 +55,8 @@
                                         'name'        => 'contact[main][first_name]',
                                         'id'          => 'first_name',
                                         'value'       => '{{ data.first_name }}',
-                                        'custom_attr' => array( 'maxlength' => $custom_attr_length )
+                                        'custom_attr' => array( 'maxlength' => $custom_attr_length ),
+                                        'required'    => true
                                     ) ); ?>
                                 </div>
                                 <div class="col-3">
@@ -74,7 +75,8 @@
                                         'name'        => 'contact[main][company]',
                                         'id'          => 'company',
                                         'value'       => '{{ data.company }}',
-                                        'custom_attr' => array( 'maxlength' => $custom_attr_length )
+                                        'custom_attr' => array( 'maxlength' => $custom_attr_length ),
+                                        'required'    => true
                                     ) ); ?>
                                 </div>
                             <# } #>
@@ -88,7 +90,8 @@
                                     'name'     => 'contact[main][email]',
                                     'value'    => '{{ data.email }}',
                                     'id'       => 'erp-crm-new-contact-email',
-                                    'type'     => 'email'
+                                    'type'     => 'email',
+                                    'required'    => true
                                 ) ); ?>
                             </div>
 
@@ -302,7 +305,7 @@
                                     'value'   => '{{ data.other }}'
                                 ) ); ?>
                             </div>
-                            
+
                             <div class="col-3">
                                 <?php erp_html_form_input( array(
                                     'label'   => __( 'Notes', 'erp' ),


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s): 
1. Current contact import system will work if any of the first_name or phone or email fields data are present. but this doesn't ensure unique contact entry on the database. If a user only provides the first_name field, the current CSV import feature treats each new submission as a new entry. Also, we can't add validation for first_name because this field is not unique. In the source, email is checked for duplicate entry, so I added the first_name and email field as required.   

2. Fixed a small CSS issue.
