### PR TITLE
CRM Contact Activity Feeds Filter - display All activities

### DIFF
--- a/modules/crm/assets/js/crm-app.js
+++ b/modules/crm/assets/js/crm-app.js
@@ -615,7 +615,7 @@ var vm = new Vue({
         },
         i18n: {},
         findFeeds: {
-            type: 'email',
+            type: 'all',
             created_from: '',
             created_to: ''
         },
@@ -982,9 +982,9 @@ var vm = new Vue({
             vm.feeds = vm.dataFeeds.filter( function( item ) {
                 if ( vm.findFeeds.created_from != '' && vm.findFeeds.created_to != '' ) {
                     var created_date = moment( item.created_at ).format('YYYY-MM-DD');
-                    return ( item.type == vm.findFeeds.type )  && ( created_date >= vm.findFeeds.created_from  &&  created_date <= vm.findFeeds.created_to );
+                    return ( vm.findFeeds.type == "all" || item.type == vm.findFeeds.type )  && ( created_date >= vm.findFeeds.created_from  &&  created_date <= vm.findFeeds.created_to );
                 } else {
-                    return item.type == vm.findFeeds.type;
+                    return vm.findFeeds.type == "all" || item.type == vm.findFeeds.type;
                 }
             } );
         }

--- a/modules/crm/views/contact/feeds.php
+++ b/modules/crm/views/contact/feeds.php
@@ -37,6 +37,7 @@ $feeds_tab = erp_crm_get_customer_feeds_nav();
     <div class="activity-content">
         <div class="activity-feed" style="margin-bottom: 10px">
             <select name="" id="" v-model="findFeeds.type"> 
+                <option value="all">All Activities</option>
                 <option value="email">Email</option>
                 <option value="tasks">Task</option>
                 <option value="log_activity">Schedule</option>


### PR DESCRIPTION
On CRM Contact Activity Feeds Filter once a filter is used added an option to remove a filter and display all activities again.


#### Changes proposed in this Pull Request:

The filtering option on the Activities Timeline in CRM Contact Profile didn't have an option to bring back the timeline of all activities once any of the filters were used.

The only solution to once again see the full list of activities was to refresh the page.


#### Related issue(s):

None that I'm aware of.


#### New look:

![image](https://user-images.githubusercontent.com/3306507/82516329-bcf74c80-9b1a-11ea-8d1d-78d46d646950.png)
