### PR TITLE
Fix/activity assign dropdown

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -2830,22 +2830,32 @@ function erp_crm_get_crm_user_dropdown( $label = [] ) {
  * @return string
  */
 function erp_crm_activity_assign_dropdown_html( $contact_id, $selected = '' ) {
-    $crm_users = erp_crm_get_crm_user();
-    $contact   = erp_get_people( $contact_id );
     $dropdown  = '';
+    $contact   = erp_get_people( $contact_id );
 
-    if ( $crm_users ) {
-        foreach ( $crm_users as $key => $user ) {
-            if ( 'erp_crm_manager' === erp_crm_get_user_role( $user->ID ) || $user->ID === intval( $contact->contact_owner ) ) {
+    if ( current_user_can( 'manage_options' ) || erp_crm_is_current_user_manager() ) {
+        $crm_users = erp_crm_get_crm_user();
 
-                if ( $user->ID == get_current_user_id() ) {
-                    $title = sprintf( '%s ( %s )', __( 'Me', 'erp' ), $user->display_name );
-                } else {
-                    $title = $user->display_name;
+        if ( $crm_users ) {
+            foreach ( $crm_users as $key => $user ) {
+                if ( 'erp_crm_manager' === erp_crm_get_user_role( $user->ID ) || $user->ID === intval( $contact->contact_owner ) ) {
+
+                    if ( $user->ID == get_current_user_id() ) {
+                        $title = sprintf( '%s ( %s )', __( 'Me', 'erp' ), $user->display_name );
+                    } else {
+                        $title = $user->display_name;
+                    }
+
+                    $dropdown .= sprintf( "<option value='%s'%s>%s</option>\n", $user->ID, selected( $selected, $user->ID, false ), $title );
                 }
-
-                $dropdown .= sprintf( "<option value='%s'%s>%s</option>\n", $user->ID, selected( $selected, $user->ID, false ), $title );
             }
+        }
+    } else {
+        $curr_user = wp_get_current_user();
+
+        if( intval( $curr_user->ID ) === intval( $contact->contact_owner ) ) {
+            $title = sprintf( '%s ( %s )', __( 'Me', 'erp' ), $curr_user->display_name );
+            $dropdown .= sprintf( "<option value='%s'%s>%s</option>", $curr_user->ID, 'selected', $title );
         }
     }
 

--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -2820,6 +2820,39 @@ function erp_crm_get_crm_user_dropdown( $label = [] ) {
 }
 
 /**
+ * Retrieves crm manager and contact owner html dropdown for assigning activity
+ *
+ * @since 1.6.7
+ *
+ * @param int $contact_id
+ * @param string $selected
+ *
+ * @return string
+ */
+function erp_crm_activity_assign_dropdown_html( $contact_id, $selected = '' ) {
+    $crm_users = erp_crm_get_crm_user();
+    $contact   = erp_get_people( $contact_id );
+    $dropdown  = '';
+
+    if ( $crm_users ) {
+        foreach ( $crm_users as $key => $user ) {
+            if ( 'erp_crm_manager' === erp_crm_get_user_role( $user->ID ) || $user->ID === intval( $contact->contact_owner ) ) {
+
+                if ( $user->ID == get_current_user_id() ) {
+                    $title = sprintf( '%s ( %s )', __( 'Me', 'erp' ), $user->display_name );
+                } else {
+                    $title = $user->display_name;
+                }
+
+                $dropdown .= sprintf( "<option value='%s'%s>%s</option>\n", $user->ID, selected( $selected, $user->ID, false ), $title );
+            }
+        }
+    }
+
+    return $dropdown;
+}
+
+/**
  * Get schedule notification type
  *
  * @since 1.0

--- a/modules/crm/views/js-templates/customer-schedule-note.php
+++ b/modules/crm/views/js-templates/customer-schedule-note.php
@@ -46,7 +46,7 @@ $notification_types = erp_crm_activity_schedule_notification_type();
     <div class="clearfix"></div>
     <p>
         <select name="invite_contact" id="erp-crm-activity-invite-contact" v-model="feedData.inviteContact" v-selecttwo="feedData.inviteContact" class="select2" multiple="multiple" style="width: 100%" data-placeholder="<?php esc_attr_e( 'Agents or managers..', 'erp' ); ?>">
-            <?php echo wp_kses( erp_crm_get_crm_user_html_dropdown(), [
+            <?php echo wp_kses( erp_crm_activity_assign_dropdown_html( $customer_id ), [
                 'option' => [
                     'value'    => [],
                     'selected' => [],

--- a/modules/crm/views/js-templates/customer-tasks-note.php
+++ b/modules/crm/views/js-templates/customer-tasks-note.php
@@ -9,7 +9,7 @@ $customer_id = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
         </p>
         <p class="assign-taskes-users">
             <select name="selected_contact" v-model="feedData.inviteContact" v-selecttwo="feedData.inviteContact" class="select2" multiple="multiple" style="width: 100%" data-placeholder="<?php esc_attr_e( 'Agents or managers..', 'erp' ); ?>">
-                <?php echo wp_kses( erp_crm_get_crm_user_html_dropdown(), [
+                <?php echo wp_kses( erp_crm_activity_assign_dropdown_html( $customer_id ), [
                     'option' => [
                         'value'    => [],
                         'selected' => [],


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Added manager + contact_owner dropdown to assign activity, where manager can assign activity to other managers or the contact owner, and crm agent can assign activity to himself only.
