### PR TITLE
Fixed limitations on employee history

### DIFF
--- a/modules/hrm/includes/class-ajax.php
+++ b/modules/hrm/includes/class-ajax.php
@@ -1158,7 +1158,7 @@ class Ajax_Handler {
 
         $fields = [
             'user_id'             => $user_id,
-            'terminate_date'      => $terminate_date,
+            'terminate_date'      => erp_current_datetime()->modify( $terminate_date )->format( 'Y-m-d H:i:s' ),
             'termination_type'    => $termination_type,
             'termination_reason'  => $termination_reason,
             'eligible_for_rehire' => $eligible_for_rehire,

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -1777,12 +1777,19 @@ class Employee {
 
         do_action( 'erp_hr_employee_job_info_create', $this->get_user_id() );
 
-        $this->erp_user->update( [
-            'designation'  => $args['designation'],
-            'department'   => $args['department'],
-            'reporting_to' => $args['reporting_to'],
-            'location'     => $args['location'],
-        ] );
+        $future_history = $this->erp_user->histories()
+                                        ->where( 'module', 'job' )
+                                        ->where( 'date', '>', $args['date'] )
+                                        ->count();
+
+        if ( (int) $future_history === 0 ) {
+            $this->erp_user->update( [
+                'designation'  => $args['designation'],
+                'department'   => $args['department'],
+                'reporting_to' => $args['reporting_to'],
+                'location'     => $args['location'],
+            ] );
+        }
 
         $history = $this->get_erp_user()->histories()->updateOrCreate( [ 'id' => $args['id'] ], [
             'date'     => $args['date'],

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -2364,11 +2364,24 @@ class Employee {
             __( 'Eligible for Hire', 'erp' ),
             erp_hr_get_terminate_rehire_options( $args['eligible_for_rehire'] ) );
 
-        $this->update_employment_status( [
-            'status'   => 'terminated',
-            'comments' => $comments,
-            'date'     => $args['terminate_date'],
-        ] );
+        if ( ! isset( $args['module'] ) ) {
+            $args['module'] = 'employee';
+        }
+    
+        if ( ! isset( $args['category'] ) ) {
+            $args['category'] = 'terminated';
+        }
+    
+        if ( ! isset( $args['date'] ) ) {
+            $args['date'] = $args['terminate_date'];
+        }
+
+        if ( ! isset( $args['comments'] ) ) {
+            $args['comments'] = $comments;
+        }
+
+        $this->update_employment_status( $args );
+    
 
         update_user_meta( $this->id, '_erp_hr_termination', $args );
 

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -1712,10 +1712,17 @@ class Employee {
 
         do_action( 'erp_hr_employee_compensation_create', $this->get_user_id() );
 
-        $this->erp_user->update( [
-            'pay_rate' => floatval( $args['pay_rate'] ),
-            'pay_type' => $args['pay_type'],
-        ] );
+        $future_history = $this->erp_user->histories()
+                                        ->where( 'module', 'compensation' )
+                                        ->where( 'date', '>', $args['date'] )
+                                        ->count();
+
+        if ( (int) $future_history === 0 ) {
+            $this->erp_user->update( [
+                'pay_rate' => floatval( $args['pay_rate'] ),
+                'pay_type' => $args['pay_type'],
+            ] );
+        }
 
         $history = $this->get_erp_user()->histories()->updateOrCreate( [ 'id' => $args['id'] ], [
             'module'   => 'compensation',

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -2381,7 +2381,6 @@ class Employee {
         }
 
         $this->update_employment_status( $args );
-    
 
         update_user_meta( $this->id, '_erp_hr_termination', $args );
 

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -1524,6 +1524,7 @@ class Employee {
         }
 
         $histories = $histories->orderBy( 'date', 'desc' )
+                            ->orderBy( 'id', 'desc' )         
                             ->skip( $offset )
                             ->take( $limit )
                             ->get();
@@ -1632,6 +1633,8 @@ class Employee {
         $args     = wp_parse_args( $args, $default );
         $types    = erp_hr_get_employee_types();
         $statuses = erp_hr_get_employee_statuses();
+
+        $args['date'] = erp_current_datetime()->modify( $args['date'] )->format( 'Y-m-d H:i:s' );
 
         if ( empty( $args['category'] ) ) {
             if ( empty( $args['type'] ) || ! array_key_exists( $args['type'], $types ) ) {

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -1523,7 +1523,7 @@ class Employee {
             $histories = $histories->where( 'module', $module );
         }
 
-        $histories = $histories->orderBy( 'id', 'desc' )
+        $histories = $histories->orderBy( 'date', 'desc' )
                             ->skip( $offset )
                             ->take( $limit )
                             ->get();

--- a/modules/hrm/includes/class-employee.php
+++ b/modules/hrm/includes/class-employee.php
@@ -1644,19 +1644,27 @@ class Employee {
         }
 
         do_action( 'erp_hr_employee_employment_status_create', $this->get_user_id() );
+        
+        $future_history = $this->erp_user->histories()
+                                        ->where( 'module', $args['module'] )
+                                        ->where( 'date', '>', $args['date'] )
+                                        ->count();
 
-        if ( ! empty( $args['type'] ) ) {
-            $this->erp_user->update( [
-                'type' => $args['type'],
-            ] );
-        }
+        if ( (int) $future_history === 0 ) {
+            
+            if ( ! empty( $args['type'] ) ) {
+                $this->erp_user->update( [
+                    'type' => $args['type'],
+                ] );
+            }
 
-        if ( ! empty( $args['category'] ) ) {
-            $this->erp_user->update( [
-                'status' => $args['category'],
-            ] );
+            if ( ! empty( $args['category'] ) ) {
+                $this->erp_user->update( [
+                    'status' => $args['category'],
+                ] );
 
-            do_action( 'erp_hr_employee_after_update_status', $this->erp_user->user_id, $args['category'], $args['date'] );
+                do_action( 'erp_hr_employee_after_update_status', $this->erp_user->user_id, $args['category'], $args['date'] );
+            }
         }
 
         $history = $this->get_erp_user()->histories()->updateOrCreate( [ 'id' => $args['id'] ], [

--- a/modules/hrm/views/employee/single.php
+++ b/modules/hrm/views/employee/single.php
@@ -84,7 +84,7 @@
                                 }
                                 ?>
 
-                                <?php if ( $employee->get_status() != 'Terminated' && current_user_can( 'erp_create_employee' ) ) { ?>
+                                <?php if ( $employee->get_status() != 'terminated' && current_user_can( 'erp_create_employee' ) ) { ?>
                                     <a class="button" href="#" id="erp-employee-terminate" data-id="<?php echo esc_html( $employee->get_user_id() ); ?>" data-template="erp-employment-terminate" data-title="<?php esc_html_e( 'Terminate Employee', 'erp' ); ?>"><?php esc_html_e( 'Terminate', 'erp' ); ?></a>
                                 <?php } ?>
 

--- a/modules/hrm/views/employee/tab-job.php
+++ b/modules/hrm/views/employee/tab-job.php
@@ -37,7 +37,7 @@
                             <?php echo ( ! empty( $employment_history['comments'] ) ) ? wp_kses_post( $employment_history['comments'] ) : '--'; ?>
                         </td>
                         <td class="action">
-                            <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) ) { ?>
+                            <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) && ( 0 !== $num ) ) { ?>
                                 <a href="#" class="remove" data-id="<?php echo esc_html( $employment_history['id'] ); ?>"><span class="dashicons dashicons-trash"></span></a>
                             <?php } ?>
                         </td>
@@ -91,7 +91,7 @@
                             <?php echo ( ! empty( $employment_history['comments'] ) ) ? wp_kses_post( $employment_history['comments'] ) : '--'; ?>
                         </td>
                         <td class="action">
-                            <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) ) { ?>
+                            <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) && ( 0 !== $num ) ) { ?>
                                 <a href="#" class="remove" data-id="<?php echo esc_html( $employment_history['id'] ); ?>"><span class="dashicons dashicons-trash"></span></a>
                             <?php } ?>
                         </td>
@@ -155,7 +155,7 @@
                                 <?php echo ( ! empty( $compensation['comment'] ) ) ? wp_kses_post( $compensation['comment'] ) : '--'; ?>
                             </td>
                             <td class="action">
-                                <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) ) { ?>
+                                <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) && ( 0 !== $num ) ) { ?>
                                     <a href="#" class="remove" data-id="<?php echo esc_html( $compensation['id'] ); ?>"><span class="dashicons dashicons-trash"></span></a>
                                 <?php } ?>
                             </td>
@@ -228,7 +228,7 @@
                     ?>
                     </td>
                     <td class="action">
-                        <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) ) { ?>
+                        <?php if ( current_user_can( 'erp_manage_jobinfo', $employee->get_user_id() ) && ( 0 !== $num ) ) { ?>
                             <a href="#" class="remove" data-id="<?php echo esc_html( $row['id'] ); ?>"><span class="dashicons dashicons-trash"></span></a>
                         <?php } ?>
                     </td>

--- a/modules/hrm/views/js-templates/employee-terminate.php
+++ b/modules/hrm/views/js-templates/employee-terminate.php
@@ -3,11 +3,12 @@
 <div class="terminate-form-wrap">
     <div class="row">
         <?php erp_html_form_input( [
-            'label'    => __( 'Termination Date', 'erp' ),
-            'name'     => 'terminate_date',
-            'value'    => '{{data.terminate_date}}',
-            'required' => true,
-            'class'    => 'erp-date-field',
+            'label'       => __( 'Termination Date', 'erp' ),
+            'name'        => 'terminate_date',
+            'value'       => '{{data.terminate_date}}',
+            'required'    => true,
+            'custom_attr' => [ 'autocomplete' => 'off' ],
+            'class'       => 'erp-date-field',
         ] ); ?>
     </div>
 


### PR DESCRIPTION
[fix] Employee history was not showing the current value correctly
[fix] Terminate option was showing for already terminated employees
[fix] Compensation history from past was updating the current value of employee
[update] Delete option has been disabled for current history