### PR TITLE
fixed empty value field problem if multiple gravity-form field map to same contact field

### DIFF
--- a/modules/crm/includes/contact-forms/class-contact-forms-integration.php
+++ b/modules/crm/includes/contact-forms/class-contact-forms-integration.php
@@ -109,8 +109,10 @@ class Contact_Forms_Integration {
                         $is_nested = preg_match_all( '/(.*)\.(.*)/', $option, $match );
 
                         if ( $is_nested ) {
-                            $contact[ $match[1][0] ][ $match[2][0] ] = $data[ $field ];
-                        } else {
+                            if ( empty( $contact[ $match[1][0] ] ) || empty( $contact[ $match[1][0] ][ $match[2][0] ] ) ) {
+                                $contact[ $match[1][0] ][ $match[2][0] ] = $data[ $field ];
+                            }
+                        } elseif ( empty( $contact[ $option ] ) ) {
                             $contact[ $option ] = $data[ $field ];
                         }
                     }


### PR DESCRIPTION
say, gravity-form field id 12, 13, 44 etc maps to same contact field 'street_2', then if gravity-form field 12 has value but others are empty and the sequence of execution is 12, 13, 44 then the value in contact['street_2'] set by gravity-form field 12 was being overridden by gravity-form field 13 and 44. Now we have checked if `contact[ $field ]` is already filled to prevent override.