### PR TITLE
Fix/transactions filter not loading all people customer vendor

### DIFF
--- a/modules/accounting/assets/src/admin/components/transactions/expenses/Expenses.vue
+++ b/modules/accounting/assets/src/admin/components/transactions/expenses/Expenses.vue
@@ -31,6 +31,7 @@ import ExpensesStats from 'admin/components/transactions/expenses/ExpensesStats.
 import ExpensesList from 'admin/components/transactions/expenses/ExpensesList.vue';
 import TransactionsFilter from 'admin/components/transactions/TransactionsFilter.vue';
 import {mapState} from "vuex";
+import HTTP from 'admin/http';
 
 export default {
     name: 'Expenses',
@@ -61,7 +62,15 @@ export default {
     },
     created() {
         if(!this.people.length){
-            this.$store.dispatch('expense/fetchPeople');
+            HTTP.get('/people', {
+                params: {
+                    type: 'all',
+                    per_page: -1,
+                    page: 1 // *offset issue
+                }
+            }).then(response => {
+                this.$store.dispatch('expense/fillPeople', response.data);
+            });
         }
     },
     computed: mapState({

--- a/modules/accounting/assets/src/admin/components/transactions/purchases/Purchases.vue
+++ b/modules/accounting/assets/src/admin/components/transactions/purchases/Purchases.vue
@@ -31,6 +31,7 @@ import PurchasesStats from 'admin/components/transactions/purchases/PurchasesSta
 import PurchasesList from 'admin/components/transactions/purchases/PurchasesList.vue';
 import TransactionsFilter from 'admin/components/transactions/TransactionsFilter.vue';
 import {mapState} from "vuex";
+import HTTP from "admin/http";
 
 export default {
     name: 'Purchases',
@@ -71,7 +72,15 @@ export default {
         }, 200);
 
         if(!this.vendors.length){
-            this.$store.dispatch('purchase/fetchVendors');
+            HTTP.get('/people', {
+                params: {
+                    type: 'vendor',
+                    per_page: -1,
+                    page: 1 // *offset issue
+                }
+            }).then(response => {
+                this.$store.dispatch('purchase/fillVendors', response.data);
+            });
         }
     }
 

--- a/modules/accounting/assets/src/admin/components/transactions/sales/Sales.vue
+++ b/modules/accounting/assets/src/admin/components/transactions/sales/Sales.vue
@@ -27,6 +27,7 @@ import SalesStats from 'admin/components/transactions/sales/SalesStats.vue';
 import SalesList from 'admin/components/transactions/sales/SalesList.vue';
 import TransactionsFilter from 'admin/components/transactions/TransactionsFilter.vue';
 import {mapState} from "vuex";
+import HTTP from 'admin/http';
 
 export default {
     name: 'Sales',
@@ -66,7 +67,15 @@ export default {
         }, 200);
 
         if(!this.customers.length){
-            this.$store.dispatch('sales/fillCustomers', []);
+            HTTP.get('/people', {
+                params: {
+                    type    : 'customer',
+                    per_page: -1,
+                    page    : 1,
+                }
+            }).then(response => {
+                this.$store.dispatch('sales/fillCustomers', response.data);
+            });
         }
     },
 


### PR DESCRIPTION
[**fix**] the filter dropdown for people, customer, vendor was loading only 10 entries instead of all the entries

part of [this](https://github.com/wp-erp/erp-pro/pull/119)