### PR TITLE
fix/crm-lifestage-non-english-char-problem

### DIFF
--- a/modules/crm/includes/class-ajax.php
+++ b/modules/crm/includes/class-ajax.php
@@ -163,7 +163,7 @@ class Ajax_Handler {
                 if ( $_REQUEST['status'] === 'trash' ) {
                     $args['trashed'] = true;
                 } else {
-                    $args['life_stage'] = sanitize_text_field( wp_unslash( $_REQUEST['status'] ) );
+                    $args['life_stage'] = sanitize_title_with_dashes( wp_unslash( $_REQUEST['status'] ) );
                 }
             }
         }

--- a/modules/crm/views/contact/single.php
+++ b/modules/crm/views/contact/single.php
@@ -11,6 +11,7 @@ $contact_tags     = wp_get_object_terms( $customer->id, 'erp_crm_tag', [ 'orderb
 $contact_tags     = wp_list_pluck( $contact_tags, 'name' );
 $contact_list_url = add_query_arg( [ 'page' => 'erp-crm', 'section' => 'contact', 'sub-section' => 'contacts' ], admin_url( 'admin.php' ) );
 $trashed          = erp_is_people_trashed( $customer->id );
+$life_stages      = erp_crm_get_life_stages_dropdown_raw();
 ?>
 <div class="wrap erp erp-crm-customer erp-single-customer" id="wp-erp" v-cloak>
     <h2>
@@ -99,7 +100,7 @@ $trashed          = erp_is_people_trashed( $customer->id );
                                 <li><?php erp_print_key_value( __( 'Country', 'erp' ), $customer->get_country() ); ?></li>
                                 <li><?php erp_print_key_value( __( 'Postal Code', 'erp' ), $customer->get_postal_code() ); ?></li>
                                 <li><?php erp_print_key_value( __( 'Source', 'erp' ), $customer->get_source() ); ?></li>
-                                <li><?php erp_print_key_value( __( 'Life stage', 'erp' ), $customer->get_life_stage() ); ?></li>
+                                <li><?php erp_print_key_value( __( 'Life stage', 'erp' ), $life_stages[ $customer->get_life_stage() ] ); ?></li>
 
                                 <?php do_action( 'erp_crm_single_contact_basic_info', $customer ); ?>
                             </ul>


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Changed the sanitizer of status for contact to work with the non-English character generated slugs for life-stages

part of [this](https://github.com/wp-erp/erp-pro/pull/124) ERP-PRO pr