### PR TITLE
fix/email formatting doesn't persist for crm contacts

### DIFF
--- a/modules/crm/includes/class-ajax.php
+++ b/modules/crm/includes/class-ajax.php
@@ -1263,7 +1263,7 @@ class Ajax_Handler {
         $save_data       = [];
         $activity_id     = ! empty( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : '';
         $activity_type   = ! empty( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : '';
-        $message         = sanitize_textarea_field( wp_unslash( $_POST['message'] ) );
+        $message         = wp_kses_post( wp_unslash( $_POST['message'] ) );
         $user_id         = absint( wp_unslash( $_POST['user_id'] ) );
         $created_by      = ! empty( $_POST['created_by'] ) ? absint( wp_unslash( $_POST['created_by'] ) ) : '';
         $email_subject   = ! empty( $_POST['email_subject'] ) ? sanitize_text_field( wp_unslash( $_POST['email_subject'] ) ) : '';


### PR DESCRIPTION
fix for Text format not persisting on Contacts > Contact Details > Notes, Log activity, Schedule, Tasks section

- [fix] Text formats were not persisting while creating different activities for a contact/company (CRM)