### PR TITLE
Fixed contact activities were not being loaded when the user is both …

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -711,7 +711,7 @@ function erp_crm_get_feed_activity( $args = [] ) {
             $results = $results->where( 'user_id', $postdata['customer_id'] );
         }
 
-        if ( current_user_can( 'erp_crm_agent' ) ) {
+        if ( erp_crm_is_current_user_crm_agent() ) {
             $contact_owner = get_current_user_id();
             $people_ids    = array_keys( $wpdb->get_results( "SELECT id FROM {$wpdb->prefix}erp_peoples WHERE contact_owner = {$contact_owner}", OBJECT_K ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

[fix] Contact activities were not being loaded when the user is both crm manager and agent (CRM)

#### How to reproduce:
1. Create a user with both `CRM Manager` and `CRM Agent` capabilities
2. Log in as that user
3. Navigate to `Contacts` and open the contact details page for any existing contact
4. The activity list for that contact will be empty (whether activities exist or not)
5. Create a new activity
6. The activity should be created but will not be shown in the list

#### Expected behavior:
1. If the user is a CRM Manager, all activities for all contacts should be shown
2. If the user is a CRM Agent but not Manager, only the activities for his/her own contact should be shown
