### PR TITLE
🛠️ [FIX] ERP Help button displaying.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3352,7 +3352,7 @@ function erp_is_valid_contact_no( $contact_no ) {
  * @return bool
  */
 function erp_is_valid_zip_code( $zip_code ) {
-    return preg_match( '/^[A-Z0-9][ \-A-Z0-9]{3,8}+$/', $zip_code );
+    return preg_match( '/^[A-Z0-9][ \-A-Z0-9]{3,12}+$/', $zip_code );
 }
 
 /**

--- a/modules/accounting/assets/src/admin/components/menu/AccountingMenu.vue
+++ b/modules/accounting/assets/src/admin/components/menu/AccountingMenu.vue
@@ -26,7 +26,7 @@
                     </ul>
                 </li>
                 <li :key="index" v-else>
-                    <router-link :to="'/' + menu.slug">{{ menu.title }}</router-link>
+                    <router-link :to="'/' + menu.slug" v-html="menu.title">{{ menu.title }}</router-link>
                 </li>
             </template>
         </ul>

--- a/modules/accounting/includes/Classes/Admin.php
+++ b/modules/accounting/includes/Classes/Admin.php
@@ -253,7 +253,8 @@ class Admin {
         erp_add_menu(
             'accounting',
             [
-                'title'      => sprintf( '<span class="erp-help">%s</span>', __( 'Help', 'erp' ) ),
+                /*'title'      => sprintf( '<span class="erp-help">%s</span>', __( 'Help', 'erp' ) ),*/
+                'title'      => sprintf( '%s', __( 'Help', 'erp' ) ),
                 'capability' => $dashboard,
                 'slug'       => 'erp-ac-help',
                 'position'   => 200,

--- a/modules/accounting/includes/Classes/Admin.php
+++ b/modules/accounting/includes/Classes/Admin.php
@@ -253,8 +253,7 @@ class Admin {
         erp_add_menu(
             'accounting',
             [
-                /*'title'      => sprintf( '<span class="erp-help">%s</span>', __( 'Help', 'erp' ) ),*/
-                'title'      => sprintf( '%s', __( 'Help', 'erp' ) ),
+                'title'      => sprintf( '<span class="erp-help">%s</span>', __( 'Help', 'erp' ) ),
                 'capability' => $dashboard,
                 'slug'       => 'erp-ac-help',
                 'position'   => 200,


### PR DESCRIPTION
🛠️ [FIX] ERP Help button displaying.
🔨 [REFACTOR] erp_is_valid_zip_code() {3,8} to {3,12}

#### Related issue(s):
This will close [this issue](https://github.com/wp-erp/erp-pro/issues/160).