### PR TITLE
[FIX] The strings ' years, ', ' months, ' and ' days )' are not translated

### DIFF
--- a/modules/hrm/views/employee/tab-general.php
+++ b/modules/hrm/views/employee/tab-general.php
@@ -61,7 +61,7 @@
                         $emp_hdate = new DateTime( $employee->get_hiring_date() );
                         $cur_date  = new DateTime( date( 'd-m-Y' ) );
                         $interval  = $cur_date->diff( $emp_hdate );
-                        echo '( ' . $interval->y . ' years, ' . $interval->m . ' months, ' . $interval->d . ' days )';
+                        echo '( ' . $interval->y . esc_html__( ' years, ', 'erp' ) . $interval->m . esc_html__( ' months, ', 'erp' ) . $interval->d . esc_html__( ' days )', 'erp' );
                     ?>
                 </li>
                 <li><?php erp_print_key_value( __( 'Source of Hire', 'erp' ), $employee->get_hiring_source( 'view' ) ); ?></li>
@@ -227,7 +227,7 @@
                                     if ( 'percentage' === $result_type ) {
                                         echo esc_html( $result->gpa ) . '%';
                                     } elseif ( $result_type === 'grade' ) {
-                                        echo esc_html( $result->gpa ) . ' out of ' . esc_html( $result->scale );
+                                        echo esc_html( $result->gpa ) . esc_html__( ' out of ', 'erp' ) . esc_html( $result->scale );
                                     }
                                     ?>
                                 </td>

--- a/modules/hrm/views/employee/tab-general.php
+++ b/modules/hrm/views/employee/tab-general.php
@@ -11,7 +11,7 @@
             </button>
         </div>
     </div>
-    
+
     <div class="inside">
         <ul class="erp-list two-col separated">
             <li><?php erp_print_key_value( __( 'First Name', 'erp' ), $employee->first_name ); ?></li>
@@ -41,7 +41,7 @@
                 </button>
             </div>
         </div>
-        
+
         <div class="inside">
             <ul class="erp-list two-col separated">
                 <li><?php erp_print_key_value( __( 'Department', 'erp' ), $employee->get_department( 'view' ) ); ?></li>
@@ -85,7 +85,7 @@
                 </button>
             </div>
         </div>
-        
+
         <div class="inside">
             <ul class="erp-list two-col separated">
                 <li><?php erp_print_key_value( __( 'Blood Group', 'erp' ), $employee->get_bloog_group() ); ?></li>
@@ -126,7 +126,7 @@
                 </button>
             </div>
         </div>
-        
+
         <div class="inside">
 
             <?php


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

The strings ' years, ', ' months, ' and ' days )' are not translated in tab-general.php

#### Related issue(s):

Fix #1405 