### PR TITLE
[FIX] The "More" button is not translated in AccountingMenu.vue

### DIFF
--- a/modules/accounting/assets/src/admin/components/menu/AccountingMenu.vue
+++ b/modules/accounting/assets/src/admin/components/menu/AccountingMenu.vue
@@ -70,7 +70,7 @@ export default {
             // insert "more" button and duplicate the list
             primary.insertAdjacentHTML(
                 'beforeend',
-                '<li class="-more"><button type="button" aria-haspopup="true" aria-expanded="false">More <span class="dashicons dashicons-arrow-down-alt2"></span></button><ul class="-secondary">' +
+                '<li class="-more"><button type="button" aria-haspopup="true" aria-expanded="false">' + __('More', 'erp') + ' <span class="dashicons dashicons-arrow-down-alt2"></span></button><ul class="-secondary">' +
                     primary.innerHTML +
                     '</ul></li>'
             );


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:

[FIX] The "More" button is not translated in AccountingMenu.vue

#### Related issue(s):

See #1406 