### PR TITLE
Init js script for tooltip message globally in ERP instead of HRM mod…

### DIFF
--- a/assets/js/erp.js
+++ b/assets/js/erp.js
@@ -297,7 +297,7 @@ window.wperp = window.wperp || {};
             $( '.wrap.erp #message button.notice-dismiss' ).on( 'click', this.dismissNoticeMessage );
 
             this.initFields();
-            this.initToolTip();
+            this.initTipTip();
         },
 
         initTipTip: function() {

--- a/assets/js/erp.js
+++ b/assets/js/erp.js
@@ -297,8 +297,16 @@ window.wperp = window.wperp || {};
             $( '.wrap.erp #message button.notice-dismiss' ).on( 'click', this.dismissNoticeMessage );
 
             this.initFields();
+            this.initToolTip();
         },
 
+        initToolTip: function() {
+            $( '.erp-tips' ).tipTip( {
+                defaultPosition: "top",
+                fadeIn: 100,
+                fadeOut: 100
+            } );
+        },
         proPopupTooltip: function (e){
             e.preventDefault();
             $('.pro-popup').mouseover(function (e) {

--- a/assets/js/erp.js
+++ b/assets/js/erp.js
@@ -300,7 +300,7 @@ window.wperp = window.wperp || {};
             this.initToolTip();
         },
 
-        initToolTip: function() {
+        initTipTip: function() {
             $( '.erp-tips' ).tipTip( {
                 defaultPosition: "top",
                 fadeIn: 100,

--- a/modules/hrm/assets/js/hrm.js
+++ b/modules/hrm/assets/js/hrm.js
@@ -141,7 +141,6 @@
             $( '#erp-hr-employee-export-csv' ).on( 'click', this.employee.exportCsv );
 
             this.showRequestNotification();
-            this.initTipTip();
 
             // Announcements
             $( 'body' ).on( 'click', 'input[name="reset_announcement_filter"]', function( e ){
@@ -226,14 +225,6 @@
                         return false;
                     });
             });
-        },
-
-        initTipTip: function() {
-            $( '.erp-tips' ).tipTip( {
-                defaultPosition: "top",
-                fadeIn: 100,
-                fadeOut: 100
-            } );
         },
 
         requiredAlert: function( action ) {


### PR DESCRIPTION


<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Refactor JS to init tooltip globally in ERP instead of HRM module only.

#### Related issue(s):  https://github.com/wp-erp/erp-pro/issues/210
