### PR TITLE
Remove sanitizer to get the setting fields

### DIFF
--- a/includes/Settings/Ajax.php
+++ b/includes/Settings/Ajax.php
@@ -125,8 +125,7 @@ class Ajax {
             $this->send_error( erp_get_message( [ 'type' => 'error_permission' ] ) );
         }
 
-        $postdata = map_deep( wp_unslash( $_POST ), 'sanitize_text_field' );
-        $data     = Helpers::process_settings_data( $postdata );
+        $data     = Helpers::process_settings_data( $_POST );
 
         if ( is_wp_error( $data ) ) {
             $this->send_error( erp_get_message( ['type' => 'error_process'] ) );


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Remove text field sanitization to get the setting fields. Because 
- There is no write  operation in database.
- There are some the fields like `desc` which we need a HTML data.

#### Related issue(s): https://github.com/wp-erp/erp-pro/pull/228#issuecomment-1990829502
