### PR TITLE
Fix: url xss issue in crm contact groups view sub url filter_contact_…

### DIFF
--- a/modules/crm/includes/ContactSubscriberListTable.php
+++ b/modules/crm/includes/ContactSubscriberListTable.php
@@ -191,7 +191,7 @@ class ContactSubscriberListTable extends \WP_List_Table {
         $actions    = [];
         $edit_url   = '';
         $group_id   = isset( $_GET['filter_contact_group'] ) ? sanitize_text_field( wp_unslash( $_GET['filter_contact_group'] ) ) : 0;
-        $delete_url = add_query_arg( [ 'page'=>'erp-crm', 'section'=> 'contact-groups', 'action' => 'delete', 'group_id' => $group_id, 'id' => $subscriber_contact->user_id ], admin_url( 'admin.php' ) );
+        $delete_url = add_query_arg( [ 'page'=>'erp-crm', 'section'=> 'contact-groups', 'action' => 'delete', 'group_id' => intval( $group_id ), 'id' => $subscriber_contact->user_id ], admin_url( 'admin.php' ) );
 
         if ( current_user_can( 'erp_crm_delete_contact', $contact->id ) ) {
             $actions['edit']   = sprintf( '<a href="%s" data-id="%d" data-name="%s" title="%s">%s</a>', $edit_url, $subscriber_contact->user_id, $contact->get_full_name(), esc_html__( 'Edit this item', 'erp' ), esc_html__( 'Edit', 'erp' ) );


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s): 
Posted in [Patchstack](https://patchstack.com/database/report-preview/d056b09b-c745-4720-a164-bd225d32fcc0?pin=ATZY4PYljB9rPBbU) 

XSS issue in CRM > Contact > Contact Group > View Subscriber

admin Create 1 new contact and 1 contact group then assign a contact.Note the contact's id. If the contact's ID is 2, change the payload in the parameter filter_contact_group=2"+autofocus+onfocus=alert(1)+x="1

http://localhost:8085/wordpress/wp-admin/admin.php?page=erp-crm&section=contact&sub-section=contact-groups&groupaction=view-subscriber&filter_contact_group=1%22+autofocus+onfocus%3Dalert%281%29+x%3D%221&paged=1
