### PR TITLE
Fix: Unauthorized Access to Terminated Employee Information

### DIFF
--- a/modules/hrm/views/employee/single.php
+++ b/modules/hrm/views/employee/single.php
@@ -3,7 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly
 }
 
-if ( !is_admin() || !current_user_can( 'erp_hr_manager' ) ||  ( $employee->get_status() == 'terminated' &&  absint( $employee->get_user_id() ) === get_current_user_id()) ) {
+
+if ( $employee->get_status() == 'terminated' && ! current_user_can( 'erp_hr_manager' ) || ! is_admin() ) {
     wp_die( __( 'You do not have sufficient permissions to access this page.', 'erp' ) );
 }
 

--- a/modules/hrm/views/employee/single.php
+++ b/modules/hrm/views/employee/single.php
@@ -1,3 +1,14 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+if ( !is_admin() || !current_user_can( 'erp_hr_manager' ) ||  ( $employee->get_status() == 'terminated' &&  absint( $employee->get_user_id() ) === get_current_user_id()) ) {
+    wp_die( __( 'You do not have sufficient permissions to access this page.', 'erp' ) );
+}
+
+?>
+
 <div class="wrap erp erp-hr-employees erp-employee-single">
 
     <?php


### PR DESCRIPTION
fixes [#266](https://github.com/wp-erp/erp-pro/issues/266)

Terminated employee data can't be viewed by other employee who didn't have access.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

