### PR TITLE
check and Intercept if user has employee if tried to delete

### DIFF
--- a/modules/hrm/includes/actions-filters.php
+++ b/modules/hrm/includes/actions-filters.php
@@ -32,3 +32,9 @@ add_action( 'erp_hr_happened_birthday_today', 'erp_hr_send_birthday_wish_email',
 add_action( 'erp_daily_scheduled_events', 'erp_hr_holiday_reminder_to_employees' );
 
 add_action( 'erp_hr_people_menu', 'erp_hr_get_people_menu_html' );
+
+ // * Check if the bulk delete action is being performed on WP Users
+add_action('admin_init', 'intercept_bulk_wpuser_delete', 8);
+
+// Intercept single user deletion
+add_action('delete_user',  'intercept_single_user_delete', 9);


### PR DESCRIPTION
I've added intercept functionality when the admin try to delete User or bulk user.
If they have linked employee account it will prevent and notice for this action.


<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
fixed #1504 

#### Related issue(s):
