### PR TITLE
[FIX] he texts of the active and install actions of the WP ERP PDF extension are not translatable

### DIFF
--- a/modules/accounting/Accounting.php
+++ b/modules/accounting/Accounting.php
@@ -118,7 +118,6 @@ final class Accounting {
         $actual_link = "{$host}{$uri}";
 
         echo '<div class="updated notice is-dismissible notice-pdf"><p>';
-        // translators: %1$s: 'install' or 'active', %2$s: link, %3$s: type
         echo wp_kses_post( sprintf(
             // translators: %1$s: 'install' or 'active', %2$s: link, %3$s: type
             __( 'Please %1$s <a href="%2$serp-pdf=%3$s">WP ERP PDF</a> extension to get PDF export feature.', 'erp' ),


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
[FIX] he texts of the active and install actions of the WP ERP PDF extension are not translatable

#### Related issue(s):
Fix #1396 