### PR TITLE
fix: announcement formating

### DIFF
--- a/modules/hrm/includes/API/AnnouncementsController.php
+++ b/modules/hrm/includes/API/AnnouncementsController.php
@@ -322,7 +322,7 @@ class AnnouncementsController extends REST_Controller {
                     'type'        => 'string',
                     'context'     => [ 'edit' ],
                     'arg_options' => [
-                        'sanitize_callback' => 'sanitize_text_field',
+                        'sanitize_callback' => 'wp_kses_post',
                     ],
                     'required'    => true,
                 ],


### PR DESCRIPTION

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
This pull request updates the sanitization method for announcement content in the `AnnouncementsController` API. The change allows richer HTML content in announcement fields by switching to a more permissive sanitization function.

**API input sanitization:**

* Changed the `sanitize_callback` for announcement content from `sanitize_text_field` to `wp_kses_post` in `get_item_schema`, allowing safe HTML tags in announcement fields.


#### Related issue(s):
fixes #1541 
