### PR TITLE
Add HRM CLI seeders for demo data generation

### DIFF
--- a/modules/hrm/includes/CLI/Commands.php
+++ b/modules/hrm/includes/CLI/Commands.php
@@ -8,6 +8,39 @@ use WP_CLI_Command;
 /**
  * HRM CLI class
  */
+
+/**
+ * HRM CLI Commands
+ * # Master command - seeds everything
+ *    wp hr clean
+ *    wp hr seed
+
+ *   # With options
+ *   wp hr seed --employees=100 --clean-first
+ *   wp hr seed --skip=shifts,attendance,training,assets,payroll
+ *   wp hr seed --only=financial-years,departments,designations,employees
+ *
+ *  # Individual seeders
+ *   wp hr seed:financial-years
+ *   wp hr seed:departments
+ *   wp hr seed:designations
+ *   wp hr seed:employees
+ *   wp hr seed:leave-types
+ *   wp hr seed:leave-policies
+ *   wp hr seed:leave-entitlements
+ *   wp hr seed:leave-requests
+ *   wp hr seed:leave-approvals
+ *   wp hr seed:holidays
+ *   wp hr seed:shifts
+ *   wp hr seed:attendance
+ *   wp hr seed:training
+ *   wp hr seed:assets
+ *   wp hr seed:payroll
+ *   wp hr seed:announcements
+
+ *  # Clean data
+ *  wp hr clean
+ */
 class Commands extends WP_CLI_Command {
 
     /**
@@ -21,6 +54,7 @@ class Commands extends WP_CLI_Command {
         global $wpdb;
 
         $tables = [
+            'erp_hr_financial_years',
             'erp_hr_depts',
             'erp_hr_designations',
             'erp_hr_employees',
@@ -47,3 +81,22 @@ class Commands extends WP_CLI_Command {
 }
 
 WP_CLI::add_command( 'hr', 'WeDevs\ERP\HRM\CLI\Commands' );
+
+// Auto-load seed files
+$seed_dir = __DIR__ . '/Seed';
+if (is_dir($seed_dir)) {
+    require_once $seed_dir . '/DataProvider.php';
+    require_once $seed_dir . '/AbstractSeeder.php';
+
+    // Load master seed command first
+    if (file_exists($seed_dir . '/SeedCommand.php')) {
+        require_once $seed_dir . '/SeedCommand.php';
+    }
+
+    // Load all other seed files
+    foreach (glob($seed_dir . '/Seed*.php') as $file) {
+        if (basename($file) !== 'SeedCommand.php') {
+            require_once $file;
+        }
+    }
+}

--- a/modules/hrm/includes/CLI/Seed/AbstractSeeder.php
+++ b/modules/hrm/includes/CLI/Seed/AbstractSeeder.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+abstract class AbstractSeeder extends WP_CLI_Command {
+
+    protected function ensure_admin() {
+        wp_set_current_user( 1 );
+    }
+
+    protected function store_ids( $key, $ids ) {
+        set_transient( '_erp_seed_' . $key, $ids, HOUR_IN_SECONDS );
+    }
+
+    protected function get_ids( $key ) {
+        return get_transient( '_erp_seed_' . $key );
+    }
+
+    protected function progress( $label, $count ) {
+        return \WP_CLI\Utils\make_progress_bar( $label, $count );
+    }
+
+    protected function suppress_emails() {
+        add_filter( 'pre_wp_mail', '__return_false' );
+    }
+
+    protected function is_pro_active() {
+        return class_exists( '\WeDevs\ERPPro\ERPPro' );
+    }
+
+    protected function table_exists( $table_name ) {
+        global $wpdb;
+
+        $result = $wpdb->get_var(
+            $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . $table_name )
+        );
+
+        return ! empty( $result );
+    }
+
+    protected function get_financial_year_ids() {
+        $ids = $this->get_ids( 'financial_year_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_financial_years ORDER BY start_date ASC"
+        );
+
+        return wp_list_pluck( $results, 'id' );
+    }
+
+    protected function get_financial_years() {
+        global $wpdb;
+
+        return $wpdb->get_results(
+            "SELECT * FROM {$wpdb->prefix}erp_hr_financial_years ORDER BY start_date ASC"
+        );
+    }
+
+    protected function get_department_ids() {
+        $ids = $this->get_ids( 'department_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_depts ORDER BY id ASC"
+        );
+
+        return wp_list_pluck( $results, 'id' );
+    }
+
+    protected function get_designation_ids() {
+        $ids = $this->get_ids( 'designation_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_designations ORDER BY id ASC"
+        );
+
+        return wp_list_pluck( $results, 'id' );
+    }
+
+    protected function get_employee_user_ids() {
+        $ids = $this->get_ids( 'employee_user_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT user_id FROM {$wpdb->prefix}erp_hr_employees WHERE status = 'active' ORDER BY user_id ASC"
+        );
+
+        return wp_list_pluck( $results, 'user_id' );
+    }
+
+    protected function get_leave_type_ids() {
+        $ids = $this->get_ids( 'leave_type_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_leaves ORDER BY id ASC"
+        );
+
+        return wp_list_pluck( $results, 'id' );
+    }
+
+    protected function get_leave_policy_ids() {
+        $ids = $this->get_ids( 'leave_policy_ids' );
+
+        if ( ! empty( $ids ) ) {
+            return $ids;
+        }
+
+        global $wpdb;
+
+        $results = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_leave_policies ORDER BY id ASC"
+        );
+
+        return wp_list_pluck( $results, 'id' );
+    }
+}

--- a/modules/hrm/includes/CLI/Seed/DataProvider.php
+++ b/modules/hrm/includes/CLI/Seed/DataProvider.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+class DataProvider {
+
+    public static function first_names_male() {
+        return [
+            'James', 'Robert', 'John', 'Michael', 'David',
+            'William', 'Richard', 'Joseph', 'Thomas', 'Charles',
+            'Christopher', 'Daniel', 'Matthew', 'Anthony', 'Mark',
+            'Donald', 'Steven', 'Andrew', 'Paul', 'Joshua',
+            'Kenneth', 'Kevin', 'Brian', 'George', 'Timothy',
+        ];
+    }
+
+    public static function first_names_female() {
+        return [
+            'Mary', 'Patricia', 'Jennifer', 'Linda', 'Barbara',
+            'Elizabeth', 'Susan', 'Jessica', 'Sarah', 'Karen',
+            'Lisa', 'Nancy', 'Betty', 'Margaret', 'Sandra',
+            'Ashley', 'Emily', 'Donna', 'Michelle', 'Carol',
+            'Amanda', 'Dorothy', 'Melissa', 'Deborah', 'Stephanie',
+        ];
+    }
+
+    public static function last_names() {
+        return [
+            'Smith', 'Johnson', 'Williams', 'Brown', 'Jones',
+            'Garcia', 'Miller', 'Davis', 'Rodriguez', 'Martinez',
+            'Hernandez', 'Lopez', 'Gonzalez', 'Wilson', 'Anderson',
+            'Thomas', 'Taylor', 'Moore', 'Jackson', 'Martin',
+            'Lee', 'Perez', 'Thompson', 'White', 'Harris',
+            'Sanchez', 'Clark', 'Ramirez', 'Lewis', 'Robinson',
+            'Walker', 'Young', 'Allen', 'King', 'Wright',
+            'Scott', 'Torres', 'Nguyen', 'Hill', 'Flores',
+            'Green', 'Adams', 'Nelson', 'Baker', 'Hall',
+            'Rivera', 'Campbell', 'Mitchell', 'Carter', 'Roberts',
+        ];
+    }
+
+    public static function departments() {
+        return [
+            [ 'title' => 'Engineering', 'description' => 'Software development and technical infrastructure' ],
+            [ 'title' => 'Human Resources', 'description' => 'Employee management, recruitment and compliance' ],
+            [ 'title' => 'Finance & Accounting', 'description' => 'Financial planning, budgeting and accounting' ],
+            [ 'title' => 'Marketing', 'description' => 'Brand management, campaigns and digital marketing' ],
+            [ 'title' => 'Sales', 'description' => 'Business development and client acquisition' ],
+            [ 'title' => 'Operations', 'description' => 'Day-to-day business operations and logistics' ],
+            [ 'title' => 'Product Management', 'description' => 'Product strategy, roadmap and feature planning' ],
+            [ 'title' => 'Customer Support', 'description' => 'Customer service and technical support' ],
+        ];
+    }
+
+    public static function designations() {
+        return [
+            [ 'title' => 'Chief Executive Officer', 'description' => 'Top executive responsible for company strategy' ],
+            [ 'title' => 'Chief Technology Officer', 'description' => 'Head of technology and engineering' ],
+            [ 'title' => 'VP of Engineering', 'description' => 'Vice president overseeing engineering teams' ],
+            [ 'title' => 'Engineering Manager', 'description' => 'Manages engineering team and projects' ],
+            [ 'title' => 'Senior Software Engineer', 'description' => 'Experienced developer with technical leadership' ],
+            [ 'title' => 'Software Engineer', 'description' => 'Core software development role' ],
+            [ 'title' => 'Junior Developer', 'description' => 'Entry-level development role' ],
+            [ 'title' => 'HR Manager', 'description' => 'Manages human resources operations' ],
+            [ 'title' => 'HR Executive', 'description' => 'Handles HR processes and employee relations' ],
+            [ 'title' => 'Finance Manager', 'description' => 'Manages financial operations and reporting' ],
+            [ 'title' => 'Accountant', 'description' => 'Handles bookkeeping and financial records' ],
+            [ 'title' => 'Marketing Manager', 'description' => 'Leads marketing strategy and campaigns' ],
+            [ 'title' => 'Sales Executive', 'description' => 'Handles sales and client relationships' ],
+            [ 'title' => 'Operations Lead', 'description' => 'Leads daily operations and process improvement' ],
+            [ 'title' => 'Product Manager', 'description' => 'Drives product vision and delivery' ],
+        ];
+    }
+
+    public static function leave_types() {
+        return [
+            [ 'name' => 'Annual Leave', 'description' => 'Paid vacation days for personal time off', 'days' => 20, 'color' => '#4CAF50' ],
+            [ 'name' => 'Sick Leave', 'description' => 'Leave for illness or medical appointments', 'days' => 14, 'color' => '#F44336' ],
+            [ 'name' => 'Casual Leave', 'description' => 'Short-notice leave for personal matters', 'days' => 10, 'color' => '#2196F3' ],
+            [ 'name' => 'Maternity Leave', 'description' => 'Leave for expecting mothers', 'days' => 90, 'color' => '#E91E63' ],
+            [ 'name' => 'Paternity Leave', 'description' => 'Leave for new fathers', 'days' => 10, 'color' => '#9C27B0' ],
+        ];
+    }
+
+    public static function holidays() {
+        return [
+            [ 'title' => "New Year's Day", 'month' => 1, 'day' => 1 ],
+            [ 'title' => 'Martin Luther King Jr. Day', 'month' => 1, 'day' => 20 ],
+            [ 'title' => "Presidents' Day", 'month' => 2, 'day' => 17 ],
+            [ 'title' => 'Memorial Day', 'month' => 5, 'day' => 26 ],
+            [ 'title' => 'Independence Day', 'month' => 7, 'day' => 4 ],
+            [ 'title' => 'Labor Day', 'month' => 9, 'day' => 1 ],
+            [ 'title' => 'Columbus Day', 'month' => 10, 'day' => 13 ],
+            [ 'title' => 'Veterans Day', 'month' => 11, 'day' => 11 ],
+            [ 'title' => 'Thanksgiving Day', 'month' => 11, 'day' => 27 ],
+            [ 'title' => 'Christmas Eve', 'month' => 12, 'day' => 24 ],
+            [ 'title' => 'Christmas Day', 'month' => 12, 'day' => 25 ],
+            [ 'title' => "New Year's Eve", 'month' => 12, 'day' => 31 ],
+        ];
+    }
+
+    public static function training_topics() {
+        return [
+            [ 'title' => 'Leadership Development Program', 'description' => 'Build leadership skills for team management and strategic thinking.' ],
+            [ 'title' => 'Agile & Scrum Methodology', 'description' => 'Master agile project management with Scrum framework.' ],
+            [ 'title' => 'Data Analysis Fundamentals', 'description' => 'Learn data analysis techniques and tools for business insights.' ],
+            [ 'title' => 'Effective Communication Workshop', 'description' => 'Improve professional communication and presentation skills.' ],
+            [ 'title' => 'Project Management Essentials', 'description' => 'Fundamentals of project planning, execution and delivery.' ],
+            [ 'title' => 'Cybersecurity Awareness', 'description' => 'Protect company data with security best practices.' ],
+            [ 'title' => 'Customer Service Excellence', 'description' => 'Deliver exceptional customer experience and resolve issues.' ],
+            [ 'title' => 'Financial Planning Basics', 'description' => 'Introduction to budgeting and financial forecasting.' ],
+            [ 'title' => 'Team Building & Collaboration', 'description' => 'Strengthen team dynamics and cross-functional collaboration.' ],
+            [ 'title' => 'Technical Writing Workshop', 'description' => 'Create clear documentation and technical content.' ],
+        ];
+    }
+
+    public static function asset_categories() {
+        return [
+            'IT Equipment',
+            'Furniture',
+            'Vehicles',
+            'Communication Devices',
+            'Office Supplies',
+        ];
+    }
+
+    public static function assets() {
+        return [
+            [ 'group' => 'Laptop', 'manufacturer' => 'Dell', 'model' => 'Latitude 5540', 'category' => 'IT Equipment', 'price' => 1200.00 ],
+            [ 'group' => 'Laptop', 'manufacturer' => 'Apple', 'model' => 'MacBook Pro 14', 'category' => 'IT Equipment', 'price' => 2499.00 ],
+            [ 'group' => 'Laptop', 'manufacturer' => 'Lenovo', 'model' => 'ThinkPad X1 Carbon', 'category' => 'IT Equipment', 'price' => 1450.00 ],
+            [ 'group' => 'Monitor', 'manufacturer' => 'LG', 'model' => '27UK850-W', 'category' => 'IT Equipment', 'price' => 450.00 ],
+            [ 'group' => 'Monitor', 'manufacturer' => 'Dell', 'model' => 'U2723QE', 'category' => 'IT Equipment', 'price' => 520.00 ],
+            [ 'group' => 'Keyboard', 'manufacturer' => 'Logitech', 'model' => 'MX Keys', 'category' => 'IT Equipment', 'price' => 100.00 ],
+            [ 'group' => 'Mouse', 'manufacturer' => 'Logitech', 'model' => 'MX Master 3', 'category' => 'IT Equipment', 'price' => 100.00 ],
+            [ 'group' => 'Desk', 'manufacturer' => 'Autonomous', 'model' => 'SmartDesk Pro', 'category' => 'Furniture', 'price' => 600.00 ],
+            [ 'group' => 'Chair', 'manufacturer' => 'Herman Miller', 'model' => 'Aeron', 'category' => 'Furniture', 'price' => 1400.00 ],
+            [ 'group' => 'Chair', 'manufacturer' => 'Steelcase', 'model' => 'Leap V2', 'category' => 'Furniture', 'price' => 1000.00 ],
+            [ 'group' => 'Phone', 'manufacturer' => 'Apple', 'model' => 'iPhone 15 Pro', 'category' => 'Communication Devices', 'price' => 999.00 ],
+            [ 'group' => 'Phone', 'manufacturer' => 'Samsung', 'model' => 'Galaxy S24', 'category' => 'Communication Devices', 'price' => 800.00 ],
+            [ 'group' => 'Headset', 'manufacturer' => 'Jabra', 'model' => 'Evolve2 85', 'category' => 'Communication Devices', 'price' => 380.00 ],
+            [ 'group' => 'Printer', 'manufacturer' => 'HP', 'model' => 'LaserJet Pro M404', 'category' => 'Office Supplies', 'price' => 350.00 ],
+            [ 'group' => 'Projector', 'manufacturer' => 'Epson', 'model' => 'PowerLite 1795F', 'category' => 'Office Supplies', 'price' => 750.00 ],
+        ];
+    }
+
+    public static function shift_definitions() {
+        return [
+            [ 'name' => 'Morning Shift', 'start' => '06:00:00', 'end' => '14:00:00' ],
+            [ 'name' => 'Day Shift', 'start' => '09:00:00', 'end' => '17:00:00' ],
+            [ 'name' => 'Evening Shift', 'start' => '14:00:00', 'end' => '22:00:00' ],
+        ];
+    }
+
+    public static function leave_reasons() {
+        return [
+            'Family event',
+            'Personal appointment',
+            'Vacation travel',
+            'Home maintenance',
+            'Medical checkup',
+            'Feeling unwell',
+            'Family emergency',
+            'Mental health day',
+            'Religious observance',
+            'Moving house',
+        ];
+    }
+
+    public static function announcement_templates() {
+        return [
+            [ 'title' => 'Company Annual General Meeting', 'body' => 'We are pleased to announce the upcoming Annual General Meeting. All employees are expected to attend. The agenda includes a review of company performance, future plans, and an open Q&A session with leadership.' ],
+            [ 'title' => 'Updated Work From Home Policy', 'body' => 'Please be informed about updates to our work from home policy. Employees may now work remotely up to 3 days per week with manager approval. Please review the full policy document on the HR portal.' ],
+            [ 'title' => 'Employee Wellness Program Launch', 'body' => 'We are excited to launch our new Employee Wellness Program. This program includes gym memberships, mental health support, and monthly wellness workshops. Sign up through the HR portal.' ],
+            [ 'title' => 'Quarterly Performance Review Cycle', 'body' => 'The quarterly performance review cycle begins next week. Please complete your self-assessment by the deadline. Your managers will schedule one-on-one sessions to discuss goals and feedback.' ],
+            [ 'title' => 'New Office Safety Guidelines', 'body' => 'Updated safety guidelines have been issued for all office locations. Please review the emergency procedures, fire exit routes, and first aid station locations posted on each floor.' ],
+            [ 'title' => 'IT Security Update - Password Policy', 'body' => 'As part of our ongoing security improvements, all employees must update their passwords by end of month. New passwords must be at least 12 characters with mixed case, numbers, and symbols.' ],
+            [ 'title' => 'Holiday Season Office Closure', 'body' => 'The office will be closed during the holiday season. Please plan your tasks accordingly and ensure all critical deliverables are completed before the closure period begins.' ],
+            [ 'title' => 'Team Building Event Announcement', 'body' => 'We are organizing a team building event next month. Activities include outdoor sports, team challenges, and a group dinner. Please RSVP through the events portal by end of this week.' ],
+            [ 'title' => 'New Employee Benefits Package', 'body' => 'We are pleased to announce enhanced employee benefits starting next quarter. This includes increased healthcare coverage, additional paid time off, and expanded education assistance.' ],
+            [ 'title' => 'Office Renovation Schedule', 'body' => 'Renovation work will begin on the 3rd floor next month. Affected teams will be temporarily relocated. Please check with your manager for your temporary seating arrangement.' ],
+            [ 'title' => 'Annual Company Picnic', 'body' => 'Join us for the annual company picnic! Food, games, and fun for employees and their families. Details about the venue and schedule will be shared soon.' ],
+            [ 'title' => 'Professional Development Budget', 'body' => 'Each employee has been allocated a professional development budget for this fiscal year. Use it for conferences, courses, certifications, or books. Submit requests through the learning portal.' ],
+        ];
+    }
+
+    public static function pay_item_categories() {
+        return [
+            'allowance' => [
+                [ 'name' => 'Basic Salary', 'type' => 1 ],
+                [ 'name' => 'House Rent Allowance', 'type' => 1 ],
+                [ 'name' => 'Transport Allowance', 'type' => 1 ],
+                [ 'name' => 'Medical Allowance', 'type' => 1 ],
+            ],
+            'deduction' => [
+                [ 'name' => 'Provident Fund', 'type' => 0 ],
+                [ 'name' => 'Professional Tax', 'type' => 0 ],
+            ],
+            'tax' => [
+                [ 'name' => 'Income Tax', 'type' => 2 ],
+            ],
+        ];
+    }
+
+    public static function random_element( $array ) {
+        return $array[ array_rand( $array ) ];
+    }
+
+    public static function random_date_between( $start, $end ) {
+        $start_ts = strtotime( $start );
+        $end_ts   = strtotime( $end );
+        $rand_ts  = mt_rand( $start_ts, $end_ts );
+
+        return date( 'Y-m-d', $rand_ts );
+    }
+
+    public static function random_working_date_between( $start, $end ) {
+        $max_attempts = 50;
+
+        for ( $i = 0; $i < $max_attempts; $i++ ) {
+            $date = self::random_date_between( $start, $end );
+            $dow  = date( 'N', strtotime( $date ) );
+
+            if ( $dow <= 5 ) {
+                return $date;
+            }
+        }
+
+        return $start;
+    }
+}

--- a/modules/hrm/includes/CLI/Seed/SeedAnnouncements.php
+++ b/modules/hrm/includes/CLI/Seed/SeedAnnouncements.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+/**
+ * Seed announcements
+ */
+class SeedAnnouncements extends AbstractSeeder {
+
+    /**
+     * Seed announcements
+     *
+     * ## OPTIONS
+     *
+     * [--count=<number>]
+     * : Number of announcements to create
+     * ---
+     * default: 12
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:announcements --count=12
+     *
+     * @param array $args       Positional arguments
+     * @param array $assoc_args Named arguments
+     *
+     * @return void
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $count = isset( $assoc_args['count'] ) ? absint( $assoc_args['count'] ) : 12;
+
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        // Get dependencies
+        $employee_ids = $this->get_ids( 'employees' );
+        $dept_ids     = $this->get_ids( 'departments' );
+        $desig_ids    = $this->get_ids( 'designations' );
+
+        if ( empty( $employee_ids ) ) {
+            // Fallback: query employees
+            global $wpdb;
+            $employee_ids = $wpdb->get_col( "SELECT user_id FROM {$wpdb->prefix}erp_hr_employees WHERE status = 'active'" );
+        }
+
+        if ( empty( $dept_ids ) ) {
+            // Fallback: query departments
+            global $wpdb;
+            $dept_ids = $wpdb->get_col( "SELECT id FROM {$wpdb->prefix}erp_hr_depts" );
+        }
+
+        if ( empty( $desig_ids ) ) {
+            // Fallback: query designations
+            global $wpdb;
+            $desig_ids = $wpdb->get_col( "SELECT id FROM {$wpdb->prefix}erp_hr_designations" );
+        }
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'No employees found. Run `wp hr seed:employees` first.' );
+        }
+
+        $templates = DataProvider::announcement_templates();
+        $progress  = $this->progress( 'Creating announcements', $count );
+
+        $created_ids = [];
+        $types       = [ 'all_employee', 'by_department', 'by_designation' ];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $template = DataProvider::random_element( $templates );
+            $type     = $types[ $i % 3 ];
+
+            // Generate date within the past 2 years
+            $post_date = DataProvider::random_date_between(
+                date( 'Y-m-d', strtotime( '-2 years' ) ),
+                date( 'Y-m-d' )
+            );
+
+            $post_data = [
+                'post_type'    => 'erp_hr_announcement',
+                'post_title'   => $template['title'],
+                'post_content' => $template['body'],
+                'post_status'  => 'publish',
+                'post_date'    => $post_date . ' 09:00:00',
+                'post_author'  => 1,
+            ];
+
+            $post_id = wp_insert_post( $post_data );
+
+            if ( is_wp_error( $post_id ) ) {
+                WP_CLI::warning( "Failed to create announcement: {$template['title']}" );
+                continue;
+            }
+
+            // Assign to recipients based on type
+            $selected = [];
+
+            switch ( $type ) {
+                case 'all_employee':
+                    $selected = []; // Empty means all employees
+                    break;
+
+                case 'by_department':
+                    if ( ! empty( $dept_ids ) ) {
+                        // Pick 1-3 random departments
+                        $num_depts = rand( 1, min( 3, count( $dept_ids ) ) );
+                        $selected  = array_rand( array_flip( $dept_ids ), $num_depts );
+                        if ( ! is_array( $selected ) ) {
+                            $selected = [ $selected ];
+                        }
+                    }
+                    break;
+
+                case 'by_designation':
+                    if ( ! empty( $desig_ids ) ) {
+                        // Pick 1-3 random designations
+                        $num_desigs = rand( 1, min( 3, count( $desig_ids ) ) );
+                        $selected   = array_rand( array_flip( $desig_ids ), $num_desigs );
+                        if ( ! is_array( $selected ) ) {
+                            $selected = [ $selected ];
+                        }
+                    }
+                    break;
+            }
+
+            // Use ERP function to assign announcements
+            if ( function_exists( 'erp_hr_assign_announcements_to_employees' ) ) {
+                erp_hr_assign_announcements_to_employees( $post_id, $type, $selected );
+            }
+
+            $created_ids[] = $post_id;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'announcements', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d announcements.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:announcements', SeedAnnouncements::class );

--- a/modules/hrm/includes/CLI/Seed/SeedAssets.php
+++ b/modules/hrm/includes/CLI/Seed/SeedAssets.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedAssets extends AbstractSeeder {
+
+    /**
+     * Generate assets and allocate to employees (Pro feature).
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of asset items to create.
+     * ---
+     * default: 30
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:assets
+     *     wp hr seed:assets --count=50
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        if ( ! $this->table_exists( 'erp_hr_assets' ) ) {
+            WP_CLI::warning( 'Asset management module not active (table erp_hr_assets not found). Skipping.' );
+            return;
+        }
+
+        global $wpdb;
+
+        $count        = (int) ( $assoc_args['count'] ?? 30 );
+        $employee_ids = $this->get_employee_user_ids();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        // Create asset categories.
+        $cat_table  = $wpdb->prefix . 'erp_hr_assets_category';
+        $categories = DataProvider::asset_categories();
+        $cat_ids    = [];
+
+        $progress = $this->progress( 'Creating asset categories', count( $categories ) );
+
+        foreach ( $categories as $cat_name ) {
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$cat_table} WHERE cat_name = %s",
+                    $cat_name
+                )
+            );
+
+            if ( $existing ) {
+                $cat_ids[ $cat_name ] = $existing;
+            } else {
+                $wpdb->insert(
+                    $cat_table,
+                    [ 'cat_name' => $cat_name ],
+                    [ '%s' ]
+                );
+                $cat_ids[ $cat_name ] = $wpdb->insert_id;
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        // Create assets.
+        $asset_table   = $wpdb->prefix . 'erp_hr_assets';
+        $asset_defs    = DataProvider::assets();
+        $progress      = $this->progress( 'Creating assets', $count );
+        $created_ids   = [];
+        $serial_counter = 1000;
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $def         = $asset_defs[ $i % count( $asset_defs ) ];
+            $category_id = isset( $cat_ids[ $def['category'] ] ) ? $cat_ids[ $def['category'] ] : 1;
+            $serial_counter++;
+
+            $reg_date  = DataProvider::random_date_between(
+                date( 'Y-m-d', strtotime( '-2 years' ) ),
+                date( 'Y-m-d' )
+            );
+            $exp_date  = date( 'Y-m-d', strtotime( $reg_date . ' +3 years' ) );
+            $warr_date = date( 'Y-m-d', strtotime( $reg_date . ' +1 year' ) );
+
+            $wpdb->insert(
+                $asset_table,
+                [
+                    'parent'        => 0,
+                    'category_id'   => $category_id,
+                    'item_group'    => $def['group'],
+                    'asset_type'    => 'single',
+                    'item_code'     => strtoupper( substr( $def['group'], 0, 3 ) ) . '-' . $serial_counter,
+                    'model_no'      => $def['model'],
+                    'manufacturer'  => $def['manufacturer'],
+                    'item_serial'   => 'SN-' . $serial_counter,
+                    'item_desc'     => $def['group'] . ' - ' . $def['manufacturer'] . ' ' . $def['model'],
+                    'price'         => $def['price'],
+                    'date_reg'      => $reg_date,
+                    'date_expiry'   => $exp_date,
+                    'date_warranty' => $warr_date,
+                    'allottable'    => 'yes',
+                    'status'        => 'stock',
+                ],
+                [ '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%f', '%s', '%s', '%s', '%s', '%s' ]
+            );
+
+            $created_ids[] = $wpdb->insert_id;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        // Allocate ~60% of assets to employees.
+        $history_table  = $wpdb->prefix . 'erp_hr_assets_history';
+        $allocate_count = (int) ( $count * 0.6 );
+        $progress       = $this->progress( 'Allocating assets', $allocate_count );
+
+        shuffle( $created_ids );
+
+        for ( $i = 0; $i < $allocate_count && $i < count( $created_ids ); $i++ ) {
+            $asset_id = $created_ids[ $i ];
+            $emp_id   = DataProvider::random_element( $employee_ids );
+
+            $asset = $wpdb->get_row(
+                $wpdb->prepare( "SELECT * FROM {$asset_table} WHERE id = %d", $asset_id )
+            );
+
+            if ( ! $asset ) {
+                $progress->tick();
+                continue;
+            }
+
+            $given_date  = DataProvider::random_date_between(
+                $asset->date_reg,
+                date( 'Y-m-d' )
+            );
+            $return_date = date( 'Y-m-d', strtotime( $given_date . ' +1 year' ) );
+
+            $wpdb->insert(
+                $history_table,
+                [
+                    'category_id'          => $asset->category_id,
+                    'item_group'           => $asset->id,
+                    'item_id'              => $asset->id,
+                    'allotted_to'          => $emp_id,
+                    'is_returnable'        => 'yes',
+                    'date_given'           => $given_date,
+                    'date_return_proposed'  => $return_date,
+                    'status'               => 'allotted',
+                ],
+                [ '%d', '%d', '%d', '%d', '%s', '%s', '%s', '%s' ]
+            );
+
+            // Update asset status.
+            $wpdb->update(
+                $asset_table,
+                [ 'status' => 'allotted' ],
+                [ 'id' => $asset_id ],
+                [ '%s' ],
+                [ '%d' ]
+            );
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        WP_CLI::success(
+            sprintf( 'Created %d asset categories, %d assets, allocated %d to employees.',
+                count( $cat_ids ), count( $created_ids ), $allocate_count
+            )
+        );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:assets', __NAMESPACE__ . '\\SeedAssets' );

--- a/modules/hrm/includes/CLI/Seed/SeedAttendance.php
+++ b/modules/hrm/includes/CLI/Seed/SeedAttendance.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedAttendance extends AbstractSeeder {
+
+    /**
+     * Generate attendance records (Pro feature).
+     *
+     * ## OPTIONS
+     *
+     * [--months=<months>]
+     * : Number of past months to generate attendance for.
+     * ---
+     * default: 6
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:attendance
+     *     wp hr seed:attendance --months=12
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        if ( ! $this->table_exists( 'erp_attendance_date_shift' ) ) {
+            WP_CLI::warning( 'Attendance module not active (table erp_attendance_date_shift not found). Skipping.' );
+            return;
+        }
+
+        global $wpdb;
+
+        $months       = (int) ( $assoc_args['months'] ?? 6 );
+        $employee_ids = $this->get_employee_user_ids();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        $date_shift_table = $wpdb->prefix . 'erp_attendance_date_shift';
+        $log_table        = $wpdb->prefix . 'erp_attendance_log';
+        $shift_user_table = $wpdb->prefix . 'erp_attendance_shift_user';
+
+        // Get holidays.
+        $holidays_raw = $wpdb->get_results(
+            "SELECT start, end FROM {$wpdb->prefix}erp_hr_holiday"
+        );
+
+        $holiday_dates = [];
+
+        foreach ( $holidays_raw as $h ) {
+            $current = strtotime( $h->start );
+            $end     = strtotime( $h->end );
+
+            while ( $current <= $end ) {
+                $holiday_dates[ date( 'Y-m-d', $current ) ] = true;
+                $current += 86400;
+            }
+        }
+
+        $start_date = date( 'Y-m-d', strtotime( "-{$months} months" ) );
+        $end_date   = date( 'Y-m-d', strtotime( '-1 day' ) );
+
+        // Build date range (working days only).
+        $dates = [];
+        $current = strtotime( $start_date );
+        $end_ts  = strtotime( $end_date );
+
+        while ( $current <= $end_ts ) {
+            $d   = date( 'Y-m-d', $current );
+            $dow = date( 'N', $current );
+
+            // Skip weekends (Fri=5, Sat=6 for some, or Sat=6, Sun=7).
+            if ( $dow <= 5 && ! isset( $holiday_dates[ $d ] ) ) {
+                $dates[] = $d;
+            }
+
+            $current += 86400;
+        }
+
+        $total = count( $employee_ids ) * count( $dates );
+
+        WP_CLI::log( sprintf( 'Generating attendance for %d employees over %d working days (%d records).',
+            count( $employee_ids ), count( $dates ), $total ) );
+
+        $progress   = $this->progress( 'Creating attendance records', $total );
+        $created    = 0;
+        $batch_ds   = [];
+        $batch_size = 500;
+
+        foreach ( $employee_ids as $user_id ) {
+            // Get user's shift.
+            $shift = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT s.* FROM {$wpdb->prefix}erp_attendance_shifts s
+                     JOIN {$shift_user_table} su ON s.id = su.shift_id
+                     WHERE su.user_id = %d AND s.status = 1 LIMIT 1",
+                    $user_id
+                )
+            );
+
+            if ( ! $shift ) {
+                // Default to 09:00-17:00 if no shift assigned.
+                $shift_start = '09:00:00';
+                $shift_end   = '17:00:00';
+                $shift_id    = 0;
+            } else {
+                $shift_start = $shift->start_time;
+                $shift_end   = $shift->end_time;
+                $shift_id    = $shift->id;
+            }
+
+            foreach ( $dates as $date ) {
+                // 90% attendance rate.
+                $is_present = ( mt_rand( 1, 100 ) <= 90 );
+
+                if ( ! $is_present ) {
+                    // For absent days, use shift times (schema doesn't allow NULL)
+                    $batch_ds[] = [
+                        'date'       => $date,
+                        'user_id'    => $user_id,
+                        'shift_id'   => $shift_id,
+                        'start_time' => $date . ' ' . $shift_start,
+                        'end_time'   => $date . ' ' . $shift_end,
+                        'present'    => 0,
+                        'late'       => 0,
+                        'early_left' => 0,
+                        'day_type'   => 'working_day',
+                        'created_at' => current_time( 'mysql' ),
+                    ];
+
+                    $created++;
+                    $progress->tick();
+
+                    if ( count( $batch_ds ) >= $batch_size ) {
+                        $this->insert_batch( $date_shift_table, $log_table, $batch_ds );
+                        $batch_ds = [];
+                    }
+
+                    continue;
+                }
+
+                // Randomize checkin: shift start +/- 15 min.
+                $shift_start_ts = strtotime( $date . ' ' . $shift_start );
+                $checkin_offset = mt_rand( -15, 15 ) * 60;
+                $checkin_ts     = $shift_start_ts + $checkin_offset;
+
+                // Randomize checkout: shift end +/- 30 min.
+                $shift_end_ts    = strtotime( $date . ' ' . $shift_end );
+                $checkout_offset = mt_rand( -30, 30 ) * 60;
+                $checkout_ts     = $shift_end_ts + $checkout_offset;
+
+                // Calculate late/early.
+                $late       = max( 0, $checkin_ts - $shift_start_ts );
+                $early_left = max( 0, $shift_end_ts - $checkout_ts );
+
+                $checkin_str  = date( 'Y-m-d H:i:s', $checkin_ts );
+                $checkout_str = date( 'Y-m-d H:i:s', $checkout_ts );
+                $time_worked  = $checkout_ts - $checkin_ts;
+
+                $batch_ds[] = [
+                    'date'        => $date,
+                    'user_id'     => $user_id,
+                    'shift_id'    => $shift_id,
+                    'start_time'  => $checkin_str,
+                    'end_time'    => $checkout_str,
+                    'present'     => 1,
+                    'late'        => $late,
+                    'early_left'  => $early_left,
+                    'day_type'    => 'working_day',
+                    'created_at'  => current_time( 'mysql' ),
+                    '_checkin'    => $checkin_str,
+                    '_checkout'   => $checkout_str,
+                    '_time'       => $time_worked,
+                ];
+
+                $created++;
+                $progress->tick();
+
+                if ( count( $batch_ds ) >= $batch_size ) {
+                    $this->insert_batch( $date_shift_table, $log_table, $batch_ds );
+                    $batch_ds = [];
+                }
+            }
+        }
+
+        // Insert remaining batch.
+        if ( ! empty( $batch_ds ) ) {
+            $this->insert_batch( $date_shift_table, $log_table, $batch_ds );
+        }
+
+        $progress->finish();
+
+        WP_CLI::success( sprintf( 'Created %d attendance records.', $created ) );
+    }
+
+    private function insert_batch( $date_shift_table, $log_table, $records ) {
+        global $wpdb;
+
+        foreach ( $records as $record ) {
+            $checkin  = isset( $record['_checkin'] ) ? $record['_checkin'] : null;
+            $checkout = isset( $record['_checkout'] ) ? $record['_checkout'] : null;
+            $time     = isset( $record['_time'] ) ? $record['_time'] : 0;
+
+            unset( $record['_checkin'], $record['_checkout'], $record['_time'] );
+
+            // Check if record already exists.
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$date_shift_table} WHERE date = %s AND user_id = %d",
+                    $record['date'],
+                    $record['user_id']
+                )
+            );
+
+            if ( $existing ) {
+                continue;
+            }
+
+            $wpdb->insert( $date_shift_table, $record );
+            $ds_id = $wpdb->insert_id;
+
+            // Insert log record if present.
+            if ( $record['present'] && $checkin && $ds_id ) {
+                $wpdb->insert(
+                    $log_table,
+                    [
+                        'user_id'       => $record['user_id'],
+                        'date_shift_id' => $ds_id,
+                        'checkin'       => $checkin,
+                        'checkout'      => $checkout,
+                        'time'          => $time,
+                        'created_at'    => $record['created_at'],
+                    ],
+                    [ '%d', '%d', '%s', '%s', '%d', '%s' ]
+                );
+            }
+        }
+    }
+}
+
+WP_CLI::add_command( 'hr seed:attendance', __NAMESPACE__ . '\\SeedAttendance' );

--- a/modules/hrm/includes/CLI/Seed/SeedCommand.php
+++ b/modules/hrm/includes/CLI/Seed/SeedCommand.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+/**
+ * Master seed command orchestrator
+ */
+class SeedCommand extends AbstractSeeder {
+
+    /**
+     * Seed all HRM data
+     *
+     * ## OPTIONS
+     *
+     * [--skip=<steps>]
+     * : Comma-separated list of steps to skip
+     *
+     * [--only=<steps>]
+     * : Comma-separated list of steps to run (skips all others)
+     *
+     * [--employees=<number>]
+     * : Number of employees to create
+     * ---
+     * default: 50
+     * ---
+     *
+     * [--clean-first]
+     * : Run clean command before seeding
+     *
+     * ## EXAMPLES
+     *
+     *     # Seed all data
+     *     wp hr seed
+     *
+     *     # Seed with 100 employees
+     *     wp hr seed --employees=100
+     *
+     *     # Skip pro features
+     *     wp hr seed --skip=shifts,attendance,training,assets,payroll
+     *
+     *     # Only seed basic structure
+     *     wp hr seed --only=financial-years,departments,designations,employees
+     *
+     *     # Clean and seed
+     *     wp hr seed --clean-first
+     *
+     * @param array $args       Positional arguments
+     * @param array $assoc_args Named arguments
+     *
+     * @return void
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $skip       = isset( $assoc_args['skip'] ) ? explode( ',', $assoc_args['skip'] ) : [];
+        $only       = isset( $assoc_args['only'] ) ? explode( ',', $assoc_args['only'] ) : [];
+        $employees  = isset( $assoc_args['employees'] ) ? absint( $assoc_args['employees'] ) : 20;
+        $clean_first = isset( $assoc_args['clean-first'] );
+
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        // Clean first if requested
+        if ( $clean_first ) {
+            WP_CLI::line( '' );
+            WP_CLI::line( WP_CLI::colorize( '%G=== Cleaning existing data ===%n' ) );
+            WP_CLI::runcommand( 'hr clean', [ 'launch' => false ] );
+        }
+
+        // Define all seed steps in execution order
+        $steps = [
+            'financial-years' => [
+                'title'       => 'Financial Years',
+                'command'     => 'hr seed:financial-years',
+                'args'        => '--count=3 --start-year=2024',
+                'description' => 'Creates 3 financial years (2024-2026)',
+            ],
+            'departments' => [
+                'title'       => 'Departments',
+                'command'     => 'hr seed:departments',
+                'args'        => '--count=8',
+                'description' => 'Creates 8 departments',
+            ],
+            'designations' => [
+                'title'       => 'Designations',
+                'command'     => 'hr seed:designations',
+                'args'        => '--count=15',
+                'description' => 'Creates 15 designations',
+            ],
+            'employees' => [
+                'title'       => 'Employees',
+                'command'     => 'hr seed:employees',
+                'args'        => "--count={$employees}",
+                'description' => "Creates {$employees} employees",
+            ],
+            'leave-types' => [
+                'title'       => 'Leave Types',
+                'command'     => 'hr seed:leave-types',
+                'args'        => '--count=5',
+                'description' => 'Creates 5 leave types',
+            ],
+            'leave-policies' => [
+                'title'       => 'Leave Policies',
+                'command'     => 'hr seed:leave-policies',
+                'args'        => '',
+                'description' => 'Creates ~15 leave policies',
+            ],
+            'leave-entitlements' => [
+                'title'       => 'Leave Entitlements',
+                'command'     => 'hr seed:leave-entitlements',
+                'args'        => '',
+                'description' => "Creates ~{$this->calculate_entitlements($employees)} leave entitlements",
+            ],
+            'leave-requests' => [
+                'title'       => 'Leave Requests',
+                'command'     => 'hr seed:leave-requests',
+                'args'        => '--count=100',
+                'description' => 'Creates 100 leave requests',
+            ],
+            'leave-approvals' => [
+                'title'       => 'Leave Approvals',
+                'command'     => 'hr seed:leave-approvals',
+                'args'        => '--approve-ratio=80',
+                'description' => 'Approves ~80% of leave requests',
+            ],
+            'holidays' => [
+                'title'       => 'Holidays',
+                'command'     => 'hr seed:holidays',
+                'args'        => '--years=2',
+                'description' => 'Creates ~30 holidays over 2 years',
+            ],
+            'shifts' => [
+                'title'       => 'Shifts (Pro)',
+                'command'     => 'hr seed:shifts',
+                'args'        => '',
+                'description' => 'Creates 3 shifts + assignments',
+                'pro'         => true,
+            ],
+            'attendance' => [
+                'title'       => 'Attendance (Pro)',
+                'command'     => 'hr seed:attendance',
+                'args'        => '--months=6',
+                'description' => 'Creates ~' . ( 6 * $employees * 22 ) . ' attendance records',
+                'pro'         => true,
+            ],
+            'training' => [
+                'title'       => 'Training (Pro)',
+                'command'     => 'hr seed:training',
+                'args'        => '--count=10',
+                'description' => 'Creates 10 training programs',
+                'pro'         => true,
+            ],
+            'assets' => [
+                'title'       => 'Assets (Pro)',
+                'command'     => 'hr seed:assets',
+                'args'        => '--count=30',
+                'description' => 'Creates 5 categories + 30 assets',
+                'pro'         => true,
+            ],
+            'payroll' => [
+                'title'       => 'Payroll (Pro)',
+                'command'     => 'hr seed:payroll',
+                'args'        => '--months=6',
+                'description' => 'Creates 1 pay calendar + 6 monthly payruns',
+                'pro'         => true,
+            ],
+            'announcements' => [
+                'title'       => 'Announcements',
+                'command'     => 'hr seed:announcements',
+                'args'        => '--count=12',
+                'description' => 'Creates 12 announcements',
+            ],
+        ];
+
+        // Filter steps based on --only or --skip
+        if ( ! empty( $only ) ) {
+            $steps = array_filter( $steps, function( $key ) use ( $only ) {
+                return in_array( $key, $only, true );
+            }, ARRAY_FILTER_USE_KEY );
+        } elseif ( ! empty( $skip ) ) {
+            $steps = array_filter( $steps, function( $key ) use ( $skip ) {
+                return ! in_array( $key, $skip, true );
+            }, ARRAY_FILTER_USE_KEY );
+        }
+
+        // Display execution plan
+        WP_CLI::line( '' );
+        WP_CLI::line( WP_CLI::colorize( '%G=== Seed Execution Plan ===%n' ) );
+        WP_CLI::line( '' );
+
+        foreach ( $steps as $key => $step ) {
+            $icon = isset( $step['pro'] ) && $step['pro'] ? '💎' : '✓';
+            WP_CLI::line( sprintf( '  %s %s: %s', $icon, $step['title'], $step['description'] ) );
+        }
+
+        WP_CLI::line( '' );
+        WP_CLI::confirm( 'Proceed with seeding?' );
+
+        // Execute steps
+        $start_time = time();
+        $completed  = 0;
+        $failed     = 0;
+
+        WP_CLI::line( '' );
+        WP_CLI::line( WP_CLI::colorize( '%G=== Starting Seed Process ===%n' ) );
+
+        foreach ( $steps as $key => $step ) {
+            WP_CLI::line( '' );
+            WP_CLI::line( WP_CLI::colorize( "%Y[{$step['title']}]%n" ) );
+
+            $command = trim( "{$step['command']} {$step['args']}" );
+
+            try {
+                WP_CLI::runcommand( $command, [ 'launch' => false, 'exit_error' => false ] );
+                $completed++;
+            } catch ( \Exception $e ) {
+                WP_CLI::warning( "Failed to execute: {$step['title']}" );
+                WP_CLI::line( $e->getMessage() );
+                $failed++;
+            }
+        }
+
+        // Summary
+        $duration = time() - $start_time;
+
+        WP_CLI::line( '' );
+        WP_CLI::line( WP_CLI::colorize( '%G=== Seed Summary ===%n' ) );
+        WP_CLI::line( '' );
+        WP_CLI::line( sprintf( '  Completed: %d', $completed ) );
+        if ( $failed > 0 ) {
+            WP_CLI::line( WP_CLI::colorize( sprintf( '  %%RFailed: %d%%n', $failed ) ) );
+        }
+        WP_CLI::line( sprintf( '  Duration: %s', $this->format_duration( $duration ) ) );
+        WP_CLI::line( '' );
+
+        if ( $completed > 0 && $failed === 0 ) {
+            WP_CLI::success( 'All seed operations completed successfully!' );
+        } elseif ( $completed > 0 ) {
+            WP_CLI::warning( 'Seed completed with some failures.' );
+        } else {
+            WP_CLI::error( 'Seed failed.' );
+        }
+    }
+
+    /**
+     * Calculate expected entitlements count
+     *
+     * @param int $employees Number of employees
+     *
+     * @return int
+     */
+    private function calculate_entitlements( $employees ) {
+        // ~90% active employees * 3 common leave types * 2 years
+        $active = (int) ( $employees * 0.9 );
+        return $active * 3 * 2;
+    }
+
+    /**
+     * Format duration in human readable format
+     *
+     * @param int $seconds Duration in seconds
+     *
+     * @return string
+     */
+    private function format_duration( $seconds ) {
+        if ( $seconds < 60 ) {
+            return $seconds . 's';
+        }
+
+        $minutes = floor( $seconds / 60 );
+        $seconds = $seconds % 60;
+
+        if ( $minutes < 60 ) {
+            return sprintf( '%dm %ds', $minutes, $seconds );
+        }
+
+        $hours   = floor( $minutes / 60 );
+        $minutes = $minutes % 60;
+
+        return sprintf( '%dh %dm %ds', $hours, $minutes, $seconds );
+    }
+}
+
+WP_CLI::add_command( 'hr seed', SeedCommand::class );

--- a/modules/hrm/includes/CLI/Seed/SeedDepartments.php
+++ b/modules/hrm/includes/CLI/Seed/SeedDepartments.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedDepartments extends AbstractSeeder {
+
+    /**
+     * Generate departments.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of departments to create.
+     * ---
+     * default: 8
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:departments
+     *     wp hr seed:departments --count=5
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $count       = (int) ( $assoc_args['count'] ?? 8 );
+        $departments = DataProvider::departments();
+        $count       = min( $count, count( $departments ) );
+
+        $progress    = $this->progress( 'Creating departments', $count );
+        $created_ids = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $dept = $departments[ $i ];
+
+            $result = erp_hr_create_department( [
+                'title'       => $dept['title'],
+                'description' => $dept['description'],
+                'lead'        => 0,
+                'parent'      => 0,
+                'status'      => 1,
+            ] );
+
+            if ( ! is_wp_error( $result ) ) {
+                $created_ids[] = $result;
+            } else {
+                WP_CLI::warning( "Failed to create department '{$dept['title']}': " . $result->get_error_message() );
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'department_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d departments.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:departments', __NAMESPACE__ . '\\SeedDepartments' );

--- a/modules/hrm/includes/CLI/Seed/SeedDesignations.php
+++ b/modules/hrm/includes/CLI/Seed/SeedDesignations.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedDesignations extends AbstractSeeder {
+
+    /**
+     * Generate designations.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of designations to create.
+     * ---
+     * default: 15
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:designations
+     *     wp hr seed:designations --count=10
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $count        = (int) ( $assoc_args['count'] ?? 15 );
+        $designations = DataProvider::designations();
+        $count        = min( $count, count( $designations ) );
+
+        $progress    = $this->progress( 'Creating designations', $count );
+        $created_ids = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $desig = $designations[ $i ];
+
+            $result = erp_hr_create_designation( [
+                'title'       => $desig['title'],
+                'description' => $desig['description'],
+                'status'      => 1,
+            ] );
+
+            if ( ! is_wp_error( $result ) ) {
+                $created_ids[] = $result;
+            } else {
+                WP_CLI::warning( "Failed to create designation '{$desig['title']}': " . $result->get_error_message() );
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'designation_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d designations.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:designations', __NAMESPACE__ . '\\SeedDesignations' );

--- a/modules/hrm/includes/CLI/Seed/SeedEmployees.php
+++ b/modules/hrm/includes/CLI/Seed/SeedEmployees.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+use WeDevs\ERP\HRM\Employee;
+
+class SeedEmployees extends AbstractSeeder {
+
+    /**
+     * Generate employees.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of employees to create.
+     * ---
+     * default: 50
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:employees
+     *     wp hr seed:employees --count=100
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        $count           = (int) ( $assoc_args['count'] ?? 50 );
+        $department_ids  = $this->get_department_ids();
+        $designation_ids = $this->get_designation_ids();
+
+        if ( empty( $department_ids ) || empty( $designation_ids ) ) {
+            WP_CLI::error( 'Departments and designations must be created first. Run seed:departments and seed:designations.' );
+        }
+
+        $male_names   = DataProvider::first_names_male();
+        $female_names = DataProvider::first_names_female();
+        $last_names   = DataProvider::last_names();
+
+        $employee_types = [ 'permanent', 'permanent', 'permanent', 'permanent', 'permanent', 'permanent', 'permanent', 'parttime', 'parttime', 'contract' ];
+        $genders        = [ 'male', 'male', 'male', 'female', 'female' ];
+        $marital        = [ 'single', 'married', 'married', 'single' ];
+        $countries      = [ 'US', 'US', 'US', 'GB', 'CA', 'AU' ];
+
+        $progress     = $this->progress( 'Creating employees', $count );
+        $created_ids  = [];
+        $used_emails  = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $gender     = DataProvider::random_element( $genders );
+            $first_name = ( $gender === 'male' )
+                ? DataProvider::random_element( $male_names )
+                : DataProvider::random_element( $female_names );
+            $last_name  = DataProvider::random_element( $last_names );
+
+            $email_base = strtolower( $first_name . '.' . $last_name );
+            $email      = $email_base . '@example.com';
+            $suffix     = 1;
+
+            while ( in_array( $email, $used_emails, true ) || email_exists( $email ) ) {
+                $email = $email_base . $suffix . '@example.com';
+                $suffix++;
+            }
+
+            $used_emails[] = $email;
+
+            $is_terminated = ( $i >= $count * 0.9 );
+            $status        = $is_terminated ? 'terminated' : 'active';
+
+            $hire_start = date( 'Y-m-d', strtotime( '-2 years' ) );
+            $hire_end   = date( 'Y-m-d', strtotime( '-1 month' ) );
+            $hiring_date = DataProvider::random_date_between( $hire_start, $hire_end );
+
+            $dob_start = date( 'Y-m-d', strtotime( '-55 years' ) );
+            $dob_end   = date( 'Y-m-d', strtotime( '-22 years' ) );
+            $dob       = DataProvider::random_date_between( $dob_start, $dob_end );
+
+            $dept_id  = DataProvider::random_element( $department_ids );
+            $desig_id = DataProvider::random_element( $designation_ids );
+            $emp_type = DataProvider::random_element( $employee_types );
+            $country  = DataProvider::random_element( $countries );
+            $mar_status = DataProvider::random_element( $marital );
+
+            $pay_rate = mt_rand( 3000, 15000 );
+
+            $employee_data = [
+                'user_email' => $email,
+                'personal'   => [
+                    'first_name'     => $first_name,
+                    'last_name'      => $last_name,
+                    'gender'         => $gender,
+                    'marital_status' => $mar_status,
+                    'nationality'    => $country,
+                    'date_of_birth'  => $dob,
+                    'phone'          => sprintf( '555%07d', mt_rand( 1000000, 9999999 ) ),
+                    'mobile'         => sprintf( '555%07d', mt_rand( 1000000, 9999999 ) ),
+                    'address'        => mt_rand( 100, 9999 ) . ' Main Street',
+                    'city'           => 'New York',
+                    'state'          => 'NY',
+                    'country'        => $country,
+                    'postal_code'    => sprintf( '%05d', mt_rand( 10000, 99999 ) ),
+                ],
+                'work' => [
+                    'designation'  => $desig_id,
+                    'department'   => $dept_id,
+                    'hiring_source' => 'direct',
+                    'hiring_date'  => $hiring_date,
+                    'date_of_birth' => $dob,
+                    'pay_rate'     => $pay_rate,
+                    'pay_type'     => 'monthly',
+                    'type'         => $emp_type,
+                    'status'       => $status,
+                ],
+            ];
+
+            if ( $is_terminated ) {
+                $term_date = DataProvider::random_date_between( $hiring_date, date( 'Y-m-d' ) );
+                $employee_data['work']['termination_date'] = $term_date;
+            }
+
+            $employee = new Employee( null );
+            $result   = $employee->create_employee( $employee_data );
+
+            if ( is_wp_error( $result ) ) {
+                WP_CLI::warning( "Failed to create employee '{$first_name} {$last_name}': " . $result->get_error_message() );
+            } else {
+                $created_ids[] = is_object( $result ) ? $result->get_user_id() : $result;
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'employee_user_ids', $created_ids );
+
+        // Update department leads with first employee in each department.
+        $this->update_department_leads( $department_ids );
+
+        WP_CLI::success( sprintf( 'Created %d employees.', count( $created_ids ) ) );
+    }
+
+    private function update_department_leads( $department_ids ) {
+        global $wpdb;
+
+        foreach ( $department_ids as $dept_id ) {
+            $lead = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT user_id FROM {$wpdb->prefix}erp_hr_employees WHERE department = %d AND status = 'active' ORDER BY user_id ASC LIMIT 1",
+                    $dept_id
+                )
+            );
+
+            if ( $lead ) {
+                $wpdb->update(
+                    $wpdb->prefix . 'erp_hr_depts',
+                    [ 'lead' => $lead ],
+                    [ 'id' => $dept_id ],
+                    [ '%d' ],
+                    [ '%d' ]
+                );
+            }
+        }
+    }
+}
+
+WP_CLI::add_command( 'hr seed:employees', __NAMESPACE__ . '\\SeedEmployees' );

--- a/modules/hrm/includes/CLI/Seed/SeedFinancialYears.php
+++ b/modules/hrm/includes/CLI/Seed/SeedFinancialYears.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedFinancialYears extends AbstractSeeder {
+
+    /**
+     * Generate financial years.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of financial years to create.
+     * ---
+     * default: 3
+     * ---
+     *
+     * [--start-year=<year>]
+     * : Starting year.
+     * ---
+     * default: 0
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:financial-years
+     *     wp hr seed:financial-years --count=3 --start-year=2024
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $count      = (int) ( $assoc_args['count'] ?? 3 );
+        $start_year = (int) ( $assoc_args['start-year'] ?? 0 );
+
+        if ( $start_year === 0 ) {
+            $start_year = (int) date( 'Y' ) - 2;
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'erp_hr_financial_years';
+
+        $progress   = $this->progress( 'Creating financial years', $count );
+        $created_ids = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $year       = $start_year + $i;
+            $fy_name    = "FY {$year}";
+            $start_date = strtotime( "{$year}-01-01" );
+            $end_date   = strtotime( "{$year}-12-31 23:59:59" );
+
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$table} WHERE fy_name = %s",
+                    $fy_name
+                )
+            );
+
+            if ( $existing ) {
+                $created_ids[] = $existing;
+                $progress->tick();
+                continue;
+            }
+
+            $wpdb->insert(
+                $table,
+                [
+                    'fy_name'     => $fy_name,
+                    'start_date'  => $start_date,
+                    'end_date'    => $end_date,
+                    'description' => "Financial Year {$year}",
+                    'created_by'  => get_current_user_id(),
+                    'updated_by'  => get_current_user_id(),
+                ],
+                [ '%s', '%d', '%d', '%s', '%d', '%d' ]
+            );
+
+            $created_ids[] = $wpdb->insert_id;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'financial_year_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d financial years.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:financial-years', __NAMESPACE__ . '\\SeedFinancialYears' );

--- a/modules/hrm/includes/CLI/Seed/SeedHolidays.php
+++ b/modules/hrm/includes/CLI/Seed/SeedHolidays.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedHolidays extends AbstractSeeder {
+
+    /**
+     * Generate holidays.
+     *
+     * ## OPTIONS
+     *
+     * [--years=<years>]
+     * : Number of years to generate holidays for.
+     * ---
+     * default: 2
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:holidays
+     *     wp hr seed:holidays --years=3
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $years    = (int) ( $assoc_args['years'] ?? 2 );
+        $holidays = DataProvider::holidays();
+
+        $start_year = (int) date( 'Y' ) - $years + 1;
+        $total      = count( $holidays ) * $years;
+        $progress   = $this->progress( 'Creating holidays', $total );
+        $created    = 0;
+
+        for ( $y = 0; $y < $years; $y++ ) {
+            $year = $start_year + $y;
+
+            foreach ( $holidays as $holiday ) {
+                $date = sprintf( '%d-%02d-%02d', $year, $holiday['month'], $holiday['day'] );
+
+                $result = erp_hr_leave_insert_holiday( [
+                    'title'       => $holiday['title'],
+                    'start'       => $date,
+                    'end'         => $date,
+                    'description' => $holiday['title'] . ' ' . $year,
+                ] );
+
+                if ( ! is_wp_error( $result ) ) {
+                    $created++;
+                } else {
+                    WP_CLI::warning( "Failed to create holiday '{$holiday['title']}' for {$year}: " . $result->get_error_message() );
+                }
+
+                $progress->tick();
+            }
+        }
+
+        $progress->finish();
+
+        WP_CLI::success( sprintf( 'Created %d holidays over %d years.', $created, $years ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:holidays', __NAMESPACE__ . '\\SeedHolidays' );

--- a/modules/hrm/includes/CLI/Seed/SeedLeaveApprovals.php
+++ b/modules/hrm/includes/CLI/Seed/SeedLeaveApprovals.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedLeaveApprovals extends AbstractSeeder {
+
+    /**
+     * Approve and reject leave requests.
+     *
+     * ## OPTIONS
+     *
+     * [--approve-ratio=<ratio>]
+     * : Percentage of requests to approve (0-100).
+     * ---
+     * default: 80
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:leave-approvals
+     *     wp hr seed:leave-approvals --approve-ratio=90
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        global $wpdb;
+
+        $approve_ratio = (int) ( $assoc_args['approve-ratio'] ?? 80 );
+
+        // Get all pending leave requests.
+        $requests = $wpdb->get_results(
+            "SELECT id FROM {$wpdb->prefix}erp_hr_leave_requests WHERE last_status = 2 ORDER BY id ASC"
+        );
+
+        if ( empty( $requests ) ) {
+            WP_CLI::warning( 'No pending leave requests found.' );
+            return;
+        }
+
+        $total    = count( $requests );
+        $progress = $this->progress( 'Processing leave approvals', $total );
+
+        $approved = 0;
+        $rejected = 0;
+        $pending  = 0;
+        $errors   = 0;
+
+        $reject_comments = [
+            'Insufficient team coverage during requested period.',
+            'Request conflicts with project deadline.',
+            'Please reschedule to a different week.',
+            'Team already has too many members on leave.',
+            'Critical deliverables pending, please postpone.',
+        ];
+
+        foreach ( $requests as $index => $request ) {
+            $rand = mt_rand( 1, 100 );
+
+            if ( $rand <= $approve_ratio ) {
+                // Approve.
+                $result = erp_hr_leave_request_update_status( $request->id, 1 );
+
+                if ( is_wp_error( $result ) ) {
+                    $errors++;
+                } else {
+                    $approved++;
+                }
+            } elseif ( $rand <= $approve_ratio + 15 ) {
+                // Reject.
+                $comment = DataProvider::random_element( $reject_comments );
+                $result  = erp_hr_leave_request_update_status( $request->id, 3, $comment );
+
+                if ( is_wp_error( $result ) ) {
+                    $errors++;
+                } else {
+                    $rejected++;
+                }
+            } else {
+                // Leave as pending.
+                $pending++;
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        WP_CLI::success(
+            sprintf(
+                'Processed %d leave requests: %d approved, %d rejected, %d left pending, %d errors.',
+                $total, $approved, $rejected, $pending, $errors
+            )
+        );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:leave-approvals', __NAMESPACE__ . '\\SeedLeaveApprovals' );

--- a/modules/hrm/includes/CLI/Seed/SeedLeaveEntitlements.php
+++ b/modules/hrm/includes/CLI/Seed/SeedLeaveEntitlements.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedLeaveEntitlements extends AbstractSeeder {
+
+    /**
+     * Generate leave entitlements for all employees.
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:leave-entitlements
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        global $wpdb;
+
+        $employee_ids = $this->get_employee_user_ids();
+        $leave_types  = DataProvider::leave_types();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first. Run seed:employees.' );
+        }
+
+        $policies = $wpdb->get_results(
+            "SELECT * FROM {$wpdb->prefix}erp_hr_leave_policies ORDER BY f_year ASC, leave_id ASC"
+        );
+
+        if ( empty( $policies ) ) {
+            WP_CLI::error( 'Leave policies must be created first. Run seed:leave-policies.' );
+        }
+
+        $financial_years = $this->get_financial_years();
+        $fy_map = [];
+
+        foreach ( $financial_years as $fy ) {
+            $fy_map[ $fy->id ] = $fy;
+        }
+
+        // Get employee details to check gender for gender-specific policies.
+        $emp_genders = [];
+
+        foreach ( $employee_ids as $uid ) {
+            $gender = get_user_meta( $uid, 'gender', true );
+
+            if ( empty( $gender ) ) {
+                $gender = 'male';
+            }
+
+            $emp_genders[ $uid ] = $gender;
+        }
+
+        // Get employee hiring dates.
+        $emp_hiring = [];
+
+        foreach ( $employee_ids as $uid ) {
+            $row = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT hiring_date FROM {$wpdb->prefix}erp_hr_employees WHERE user_id = %d",
+                    $uid
+                )
+            );
+
+            $emp_hiring[ $uid ] = $row ? $row->hiring_date : date( 'Y-m-d', strtotime( '-2 years' ) );
+        }
+
+        $total = count( $employee_ids ) * count( $policies );
+        $progress = $this->progress( 'Creating leave entitlements', $total );
+        $created_ids = [];
+        $skip_count  = 0;
+
+        foreach ( $employee_ids as $uid ) {
+            foreach ( $policies as $policy ) {
+                // Check gender match.
+                $leave_type_index = null;
+
+                foreach ( $leave_types as $idx => $lt ) {
+                    $lt_row = $wpdb->get_row(
+                        $wpdb->prepare(
+                            "SELECT name FROM {$wpdb->prefix}erp_hr_leaves WHERE id = %d",
+                            $policy->leave_id
+                        )
+                    );
+
+                    if ( $lt_row && $lt_row->name === $lt['name'] ) {
+                        $leave_type_index = $idx;
+                        break;
+                    }
+                }
+
+                // Skip gender-specific policies.
+                if ( $policy->gender !== '-1' && ! empty( $policy->gender ) ) {
+                    if ( $emp_genders[ $uid ] !== $policy->gender ) {
+                        $skip_count++;
+                        $progress->tick();
+                        continue;
+                    }
+                }
+
+                // Skip if employee was not yet hired in this FY.
+                if ( isset( $fy_map[ $policy->f_year ] ) ) {
+                    $fy = $fy_map[ $policy->f_year ];
+                    $hiring_ts = strtotime( $emp_hiring[ $uid ] );
+
+                    if ( $hiring_ts > $fy->end_date ) {
+                        $skip_count++;
+                        $progress->tick();
+                        continue;
+                    }
+                }
+
+                // Check if entitlement already exists.
+                $existing = $wpdb->get_var(
+                    $wpdb->prepare(
+                        "SELECT id FROM {$wpdb->prefix}erp_hr_leave_entitlements
+                         WHERE user_id = %d AND leave_id = %d AND f_year = %d AND trn_id = %d AND trn_type = 'leave_policies'",
+                        $uid,
+                        $policy->leave_id,
+                        $policy->f_year,
+                        $policy->id
+                    )
+                );
+
+                if ( $existing ) {
+                    $created_ids[] = $existing;
+                    $progress->tick();
+                    continue;
+                }
+
+                $result = erp_hr_leave_insert_entitlement( [
+                    'user_id'     => $uid,
+                    'leave_id'    => $policy->leave_id,
+                    'created_by'  => get_current_user_id(),
+                    'trn_id'      => $policy->id,
+                    'trn_type'    => 'leave_policies',
+                    'day_in'      => $policy->days,
+                    'day_out'     => 0,
+                    'description' => 'Seeded entitlement',
+                    'f_year'      => $policy->f_year,
+                ] );
+
+                if ( is_wp_error( $result ) ) {
+                    $skip_count++;
+                } else {
+                    $created_ids[] = $result;
+                }
+
+                $progress->tick();
+            }
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'entitlement_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d leave entitlements (%d skipped).', count( $created_ids ), $skip_count ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:leave-entitlements', __NAMESPACE__ . '\\SeedLeaveEntitlements' );

--- a/modules/hrm/includes/CLI/Seed/SeedLeavePolicies.php
+++ b/modules/hrm/includes/CLI/Seed/SeedLeavePolicies.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedLeavePolicies extends AbstractSeeder {
+
+    /**
+     * Generate leave policies for each leave type and financial year.
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:leave-policies
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $leave_type_ids    = $this->get_leave_type_ids();
+        $financial_year_ids = $this->get_financial_year_ids();
+
+        if ( empty( $leave_type_ids ) ) {
+            WP_CLI::error( 'Leave types must be created first. Run seed:leave-types.' );
+        }
+
+        if ( empty( $financial_year_ids ) ) {
+            WP_CLI::error( 'Financial years must be created first. Run seed:financial-years.' );
+        }
+
+        $leave_types = DataProvider::leave_types();
+        $colors      = [ '#4CAF50', '#F44336', '#2196F3', '#E91E63', '#9C27B0' ];
+
+        $total    = count( $leave_type_ids ) * count( $financial_year_ids );
+        $progress = $this->progress( 'Creating leave policies', $total );
+        $created_ids = [];
+
+        foreach ( $financial_year_ids as $fy_id ) {
+            foreach ( $leave_type_ids as $index => $leave_id ) {
+                $lt    = isset( $leave_types[ $index ] ) ? $leave_types[ $index ] : $leave_types[0];
+                $color = isset( $colors[ $index ] ) ? $colors[ $index ] : '#607D8B';
+
+                $gender = '-1';
+
+                if ( stripos( $lt['name'], 'Maternity' ) !== false ) {
+                    $gender = 'female';
+                } elseif ( stripos( $lt['name'], 'Paternity' ) !== false ) {
+                    $gender = 'male';
+                }
+
+                $policy_args = [
+                    'leave_id'            => $leave_id,
+                    'description'         => $lt['description'],
+                    'days'                => $lt['days'],
+                    'color'               => $color,
+                    'employee_type'       => '-1',
+                    'department_id'       => '-1',
+                    'designation_id'      => '-1',
+                    'location_id'         => '-1',
+                    'gender'              => $gender,
+                    'marital'             => '-1',
+                    'f_year'              => $fy_id,
+                    'applicable_from'     => 0,
+                    'apply_for_new_users' => 1,
+                ];
+
+                $result = erp_hr_leave_insert_policy( $policy_args );
+
+                if ( is_wp_error( $result ) ) {
+                    WP_CLI::warning( "Failed to create policy for leave {$leave_id}, FY {$fy_id}: " . $result->get_error_message() );
+                } else {
+                    $created_ids[] = $result;
+                }
+
+                $progress->tick();
+            }
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'leave_policy_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d leave policies.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:leave-policies', __NAMESPACE__ . '\\SeedLeavePolicies' );

--- a/modules/hrm/includes/CLI/Seed/SeedLeaveRequests.php
+++ b/modules/hrm/includes/CLI/Seed/SeedLeaveRequests.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedLeaveRequests extends AbstractSeeder {
+
+    /**
+     * Generate leave requests.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of leave requests to create.
+     * ---
+     * default: 100
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:leave-requests
+     *     wp hr seed:leave-requests --count=200
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        global $wpdb;
+
+        $count        = (int) ( $assoc_args['count'] ?? 100 );
+        $employee_ids = $this->get_employee_user_ids();
+        $reasons      = DataProvider::leave_reasons();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        $financial_years = $this->get_financial_years();
+
+        if ( empty( $financial_years ) ) {
+            WP_CLI::error( 'Financial years must be created first.' );
+        }
+
+        $progress     = $this->progress( 'Creating leave requests', $count );
+        $created_ids  = [];
+        $fail_count   = 0;
+
+        // Track used dates per employee to avoid overlaps.
+        $used_dates = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $user_id = DataProvider::random_element( $employee_ids );
+
+            // Get entitlements for this employee.
+            $entitlements = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT e.*, fy.start_date as fy_start, fy.end_date as fy_end
+                     FROM {$wpdb->prefix}erp_hr_leave_entitlements e
+                     JOIN {$wpdb->prefix}erp_hr_financial_years fy ON e.f_year = fy.id
+                     WHERE e.user_id = %d AND e.trn_type = 'leave_policies'
+                     ORDER BY RAND() LIMIT 1",
+                    $user_id
+                )
+            );
+
+            if ( empty( $entitlements ) ) {
+                $fail_count++;
+                $progress->tick();
+                continue;
+            }
+
+            $ent = $entitlements[0];
+
+            // Generate a random leave duration (1-5 days).
+            $duration = mt_rand( 1, 5 );
+
+            // Find a random start date within the financial year (convert timestamps to dates).
+            $fy_start = date( 'Y-m-d', $ent->fy_start );
+            $fy_end   = date( 'Y-m-d', $ent->fy_end );
+
+            // Ensure end date doesn't exceed FY.
+            $latest_start = date( 'Y-m-d', strtotime( $fy_end . " -{$duration} days" ) );
+
+            if ( $latest_start < $fy_start ) {
+                $fail_count++;
+                $progress->tick();
+                continue;
+            }
+
+            $start_date = DataProvider::random_working_date_between( $fy_start, $latest_start );
+            $end_date   = date( 'Y-m-d', strtotime( $start_date . " +{$duration} days" ) );
+
+            // Skip weekends for end date.
+            $dow = date( 'N', strtotime( $end_date ) );
+
+            if ( $dow == 6 ) {
+                $end_date = date( 'Y-m-d', strtotime( $end_date . ' +2 days' ) );
+            } elseif ( $dow == 7 ) {
+                $end_date = date( 'Y-m-d', strtotime( $end_date . ' +1 day' ) );
+            }
+
+            if ( $end_date > $fy_end ) {
+                $end_date = $fy_end;
+            }
+
+            // Check overlap with previous requests for this user.
+            $key = $user_id . '_' . $start_date;
+
+            if ( isset( $used_dates[ $key ] ) ) {
+                $fail_count++;
+                $progress->tick();
+                continue;
+            }
+
+            $used_dates[ $key ] = true;
+
+            $reason = DataProvider::random_element( $reasons );
+
+            $result = erp_hr_leave_insert_request( [
+                'user_id'      => $user_id,
+                'leave_policy' => $ent->id,
+                'start_date'   => $start_date,
+                'end_date'     => $end_date,
+                'reason'       => $reason,
+                'status'       => 2,
+            ] );
+
+            if ( is_wp_error( $result ) ) {
+                $fail_count++;
+            } else {
+                $created_ids[] = $result;
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'leave_request_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d leave requests (%d failed/skipped).', count( $created_ids ), $fail_count ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:leave-requests', __NAMESPACE__ . '\\SeedLeaveRequests' );

--- a/modules/hrm/includes/CLI/Seed/SeedLeaveTypes.php
+++ b/modules/hrm/includes/CLI/Seed/SeedLeaveTypes.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+use WeDevs\ERP\HRM\Models\Leave;
+
+class SeedLeaveTypes extends AbstractSeeder {
+
+    /**
+     * Generate leave types.
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of leave types to create.
+     * ---
+     * default: 5
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:leave-types
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        $count       = (int) ( $assoc_args['count'] ?? 5 );
+        $leave_types = DataProvider::leave_types();
+        $count       = min( $count, count( $leave_types ) );
+
+        $progress    = $this->progress( 'Creating leave types', $count );
+        $created_ids = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $lt = $leave_types[ $i ];
+
+            $existing = Leave::where( 'name', $lt['name'] )->first();
+
+            if ( $existing ) {
+                $created_ids[] = $existing->id;
+                $progress->tick();
+                continue;
+            }
+
+            $leave = Leave::create( [
+                'name'        => $lt['name'],
+                'description' => $lt['description'],
+            ] );
+
+            $created_ids[] = $leave->id;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'leave_type_ids', $created_ids );
+
+        WP_CLI::success( sprintf( 'Created %d leave types.', count( $created_ids ) ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:leave-types', __NAMESPACE__ . '\\SeedLeaveTypes' );

--- a/modules/hrm/includes/CLI/Seed/SeedPayroll.php
+++ b/modules/hrm/includes/CLI/Seed/SeedPayroll.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedPayroll extends AbstractSeeder {
+
+    /**
+     * Generate payroll data - pay calendar, payruns, and disburse salary (Pro feature).
+     *
+     * ## OPTIONS
+     *
+     * [--months=<months>]
+     * : Number of past months to generate payroll for.
+     * ---
+     * default: 6
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:payroll
+     *     wp hr seed:payroll --months=12
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        if ( ! $this->table_exists( 'erp_hr_payroll_pay_calendar' ) ) {
+            WP_CLI::warning( 'Payroll module not active (table erp_hr_payroll_pay_calendar not found). Skipping.' );
+            return;
+        }
+
+        global $wpdb;
+
+        $months       = (int) ( $assoc_args['months'] ?? 6 );
+        $employee_ids = $this->get_employee_user_ids();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        $cal_table       = $wpdb->prefix . 'erp_hr_payroll_pay_calendar';
+        $settings_table  = $wpdb->prefix . 'erp_hr_payroll_calendar_type_settings';
+        $cal_emp_table   = $wpdb->prefix . 'erp_hr_payroll_pay_calendar_employee';
+        $payitem_table   = $wpdb->prefix . 'erp_hr_payroll_payitem';
+        $fixed_table     = $wpdb->prefix . 'erp_hr_payroll_fixed_payment';
+        $payrun_table    = $wpdb->prefix . 'erp_hr_payroll_payrun';
+        $detail_table    = $wpdb->prefix . 'erp_hr_payroll_payrun_detail';
+
+        // 1. Create pay calendar.
+        WP_CLI::log( 'Creating pay calendar...' );
+
+        $existing_cal = $wpdb->get_var(
+            "SELECT id FROM {$cal_table} WHERE pay_calendar_name = 'Monthly Payroll' LIMIT 1"
+        );
+
+        if ( $existing_cal ) {
+            $cal_id = $existing_cal;
+        } else {
+            $wpdb->insert(
+                $cal_table,
+                [
+                    'pay_calendar_name' => 'Monthly Payroll',
+                    'pay_calendar_type' => 'monthly',
+                ],
+                [ '%s', '%s' ]
+            );
+            $cal_id = $wpdb->insert_id;
+
+            $wpdb->insert(
+                $settings_table,
+                [
+                    'pay_calendar_id'    => $cal_id,
+                    'pay_day'            => -1,
+                    'custom_month_day'   => 0,
+                    'pay_day_mode'       => 0,
+                ],
+                [ '%d', '%d', '%d', '%d' ]
+            );
+        }
+
+        // 2. Assign employees to pay calendar.
+        $progress = $this->progress( 'Assigning employees to pay calendar', count( $employee_ids ) );
+
+        foreach ( $employee_ids as $emp_id ) {
+            $exists = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$cal_emp_table} WHERE pay_calendar_id = %d AND empid = %d",
+                    $cal_id,
+                    $emp_id
+                )
+            );
+
+            if ( ! $exists ) {
+                $wpdb->insert(
+                    $cal_emp_table,
+                    [
+                        'pay_calendar_id' => $cal_id,
+                        'empid'           => $emp_id,
+                    ],
+                    [ '%d', '%d' ]
+                );
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        // 3. Get or create pay items.
+        $pay_items = $this->ensure_pay_items( $payitem_table );
+
+        // 4. Create fixed payments for employees.
+        WP_CLI::log( 'Creating fixed salary components...' );
+        $progress = $this->progress( 'Setting up fixed payments', count( $employee_ids ) );
+
+        foreach ( $employee_ids as $emp_id ) {
+            $emp = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT pay_rate FROM {$wpdb->prefix}erp_hr_employees WHERE user_id = %d",
+                    $emp_id
+                )
+            );
+
+            $basic = $emp ? (float) $emp->pay_rate : 5000;
+
+            // Basic Salary.
+            $this->insert_fixed_payment( $fixed_table, $cal_id, $emp_id, $pay_items['Basic Salary'], $basic );
+
+            // House Rent Allowance (30% of basic).
+            if ( isset( $pay_items['House Rent Allowance'] ) ) {
+                $this->insert_fixed_payment( $fixed_table, $cal_id, $emp_id, $pay_items['House Rent Allowance'], round( $basic * 0.30, 2 ) );
+            }
+
+            // Transport Allowance (flat).
+            if ( isset( $pay_items['Transport Allowance'] ) ) {
+                $this->insert_fixed_payment( $fixed_table, $cal_id, $emp_id, $pay_items['Transport Allowance'], 200 );
+            }
+
+            // Provident Fund deduction (5% of basic).
+            if ( isset( $pay_items['Provident Fund'] ) ) {
+                $this->insert_fixed_payment( $fixed_table, $cal_id, $emp_id, $pay_items['Provident Fund'], round( $basic * 0.05, 2 ) );
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        // 5. Create monthly payruns.
+        WP_CLI::log( sprintf( 'Creating %d monthly payruns...', $months ) );
+        $progress = $this->progress( 'Creating payruns', $months );
+
+        for ( $m = $months; $m >= 1; $m-- ) {
+            $from_date    = date( 'Y-m-01', strtotime( "-{$m} months" ) );
+            $to_date      = date( 'Y-m-t', strtotime( "-{$m} months" ) );
+            $payment_date = $to_date;
+
+            // Check if payrun exists.
+            $existing_pr = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$payrun_table} WHERE pay_cal_id = %d AND from_date = %s",
+                    $cal_id,
+                    $from_date
+                )
+            );
+
+            if ( $existing_pr ) {
+                $progress->tick();
+                continue;
+            }
+
+            $wpdb->insert(
+                $payrun_table,
+                [
+                    'pay_cal_id'     => $cal_id,
+                    'payment_date'   => $payment_date,
+                    'from_date'      => $from_date,
+                    'to_date'        => $to_date,
+                    'approve_status' => 1,
+                ],
+                [ '%d', '%s', '%s', '%s', '%d' ]
+            );
+
+            $payrun_id = $wpdb->insert_id;
+
+            // Create payrun details for each employee.
+            foreach ( $employee_ids as $emp_id ) {
+                $emp = $wpdb->get_row(
+                    $wpdb->prepare(
+                        "SELECT pay_rate FROM {$wpdb->prefix}erp_hr_employees WHERE user_id = %d",
+                        $emp_id
+                    )
+                );
+
+                $basic     = $emp ? (float) $emp->pay_rate : 5000;
+                $hra       = round( $basic * 0.30, 2 );
+                $transport = 200;
+                $pf        = round( $basic * 0.05, 2 );
+
+                $allowance  = $basic + $hra + $transport;
+                $deduction  = $pf;
+                $net_pay    = $allowance - $deduction;
+
+                // Basic salary detail.
+                $this->insert_payrun_detail( $detail_table, $payrun_id, $cal_id, $payment_date, $emp_id, $pay_items['Basic Salary'], $basic, 1, $allowance, $deduction );
+
+                // HRA detail.
+                if ( isset( $pay_items['House Rent Allowance'] ) ) {
+                    $this->insert_payrun_detail( $detail_table, $payrun_id, $cal_id, $payment_date, $emp_id, $pay_items['House Rent Allowance'], $hra, 1, 0, 0 );
+                }
+
+                // Transport detail.
+                if ( isset( $pay_items['Transport Allowance'] ) ) {
+                    $this->insert_payrun_detail( $detail_table, $payrun_id, $cal_id, $payment_date, $emp_id, $pay_items['Transport Allowance'], $transport, 1, 0, 0 );
+                }
+
+                // PF deduction detail.
+                if ( isset( $pay_items['Provident Fund'] ) ) {
+                    $this->insert_payrun_detail( $detail_table, $payrun_id, $cal_id, $payment_date, $emp_id, $pay_items['Provident Fund'], $pf, 0, 0, 0 );
+                }
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        WP_CLI::success(
+            sprintf(
+                'Payroll setup complete: 1 pay calendar, %d employees assigned, %d months of payruns created and disbursed.',
+                count( $employee_ids ),
+                $months
+            )
+        );
+    }
+
+    private function ensure_pay_items( $table ) {
+        global $wpdb;
+
+        $items = [
+            'Basic Salary'          => 1,
+            'House Rent Allowance'  => 1,
+            'Transport Allowance'   => 1,
+            'Medical Allowance'     => 1,
+            'Provident Fund'        => 0,
+            'Professional Tax'      => 0,
+            'Income Tax'            => 2,
+        ];
+
+        $result = [];
+
+        foreach ( $items as $name => $type ) {
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$table} WHERE payitem = %s",
+                    $name
+                )
+            );
+
+            if ( $existing ) {
+                $result[ $name ] = $existing;
+            } else {
+                $wpdb->insert(
+                    $table,
+                    [
+                        'payitem'                => $name,
+                        'pay_item_add_or_deduct' => $type,
+                        'type'                   => 'payrun',
+                    ],
+                    [ '%s', '%d', '%s' ]
+                );
+
+                $result[ $name ] = $wpdb->insert_id;
+            }
+        }
+
+        return $result;
+    }
+
+    private function insert_fixed_payment( $table, $cal_id, $emp_id, $payitem_id, $amount ) {
+        global $wpdb;
+
+        // Get pay_item_add_or_deduct from payitem table
+        $payitem_table = str_replace( 'fixed_payment', 'payitem', $table );
+        $add_or_deduct = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT pay_item_add_or_deduct FROM {$payitem_table} WHERE id = %d",
+                $payitem_id
+            )
+        );
+
+        $exists = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$table} WHERE empid = %d AND pay_item_id = %d",
+                $emp_id,
+                $payitem_id
+            )
+        );
+
+        if ( $exists ) {
+            return;
+        }
+
+        $wpdb->insert(
+            $table,
+            [
+                'pay_item_id'            => $payitem_id,
+                'pay_item_amount'        => $amount,
+                'empid'                  => $emp_id,
+                'pay_item_add_or_deduct' => $add_or_deduct,
+            ],
+            [ '%d', '%f', '%d', '%d' ]
+        );
+    }
+
+    private function insert_payrun_detail( $table, $payrun_id, $cal_id, $payment_date, $emp_id, $payitem_id, $amount, $add_or_deduct, $allowance, $deduction ) {
+        global $wpdb;
+
+        $wpdb->insert(
+            $table,
+            [
+                'payrun_id'              => $payrun_id,
+                'pay_cal_id'             => $cal_id,
+                'payment_date'           => $payment_date,
+                'empid'                  => $emp_id,
+                'pay_item_id'            => $payitem_id,
+                'pay_item_amount'        => $amount,
+                'pay_item_add_or_deduct' => $add_or_deduct,
+                'allowance'              => $allowance,
+                'deduction'              => $deduction,
+                'approve_status'         => 1,
+            ],
+            [ '%d', '%d', '%s', '%d', '%d', '%f', '%d', '%f', '%f', '%d' ]
+        );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:payroll', __NAMESPACE__ . '\\SeedPayroll' );

--- a/modules/hrm/includes/CLI/Seed/SeedShifts.php
+++ b/modules/hrm/includes/CLI/Seed/SeedShifts.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedShifts extends AbstractSeeder {
+
+    /**
+     * Generate shifts and assign employees (Pro feature).
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:shifts
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+
+        if ( ! $this->table_exists( 'erp_attendance_shifts' ) ) {
+            WP_CLI::warning( 'Attendance module not active (table erp_attendance_shifts not found). Skipping shifts.' );
+            return;
+        }
+
+        $employee_ids = $this->get_employee_user_ids();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        $shifts     = DataProvider::shift_definitions();
+        $progress   = $this->progress( 'Creating shifts', count( $shifts ) );
+        $shift_ids  = [];
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'erp_attendance_shifts';
+
+        foreach ( $shifts as $shift ) {
+            // Check if shift already exists.
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$table} WHERE name = %s",
+                    $shift['name']
+                )
+            );
+
+            if ( $existing ) {
+                $shift_ids[] = $existing;
+                $progress->tick();
+                continue;
+            }
+
+            if ( function_exists( 'erp_attendance_insert_shift' ) ) {
+                $result = erp_attendance_insert_shift(
+                    $shift['start'],
+                    $shift['end'],
+                    $shift['name'],
+                    serialize( [ 'fri', 'sat' ] ),
+                    1
+                );
+
+                if ( $result && ! is_wp_error( $result ) ) {
+                    $shift_ids[] = $result;
+                } else {
+                    WP_CLI::warning( "Failed to create shift '{$shift['name']}'." );
+                }
+            } else {
+                // Direct insert fallback.
+                $start_ts = strtotime( "1970-01-01 {$shift['start']}" );
+                $end_ts   = strtotime( "1970-01-01 {$shift['end']}" );
+                $duration = $end_ts - $start_ts;
+
+                $wpdb->insert(
+                    $table,
+                    [
+                        'name'       => $shift['name'],
+                        'start_time' => $shift['start'],
+                        'end_time'   => $shift['end'],
+                        'duration'   => $duration,
+                        'holidays'   => serialize( [ 'fri', 'sat' ] ),
+                        'status'     => 1,
+                    ],
+                    [ '%s', '%s', '%s', '%d', '%s', '%d' ]
+                );
+
+                $shift_ids[] = $wpdb->insert_id;
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        // Assign employees to shifts.
+        $shift_user_table = $wpdb->prefix . 'erp_attendance_shift_user';
+        $emp_count        = count( $employee_ids );
+        $progress         = $this->progress( 'Assigning employees to shifts', $emp_count );
+
+        shuffle( $employee_ids );
+
+        foreach ( $employee_ids as $index => $user_id ) {
+            // Distribute: 40% morning, 40% day, 20% evening.
+            if ( $index < $emp_count * 0.4 ) {
+                $shift_id = $shift_ids[0];
+            } elseif ( $index < $emp_count * 0.8 ) {
+                $shift_id = $shift_ids[1];
+            } else {
+                $shift_id = $shift_ids[2] ?? $shift_ids[1];
+            }
+
+            $existing = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$shift_user_table} WHERE user_id = %d AND shift_id = %d",
+                    $user_id,
+                    $shift_id
+                )
+            );
+
+            if ( ! $existing ) {
+                // Always use direct insert for reliability
+                $wpdb->insert(
+                    $shift_user_table,
+                    [
+                        'shift_id' => $shift_id,
+                        'user_id'  => $user_id,
+                        'status'   => 1,
+                    ],
+                    [ '%d', '%d', '%d' ]
+                );
+            }
+
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        $this->store_ids( 'shift_ids', $shift_ids );
+
+        WP_CLI::success( sprintf( 'Created %d shifts and assigned %d employees.', count( $shift_ids ), $emp_count ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:shifts', __NAMESPACE__ . '\\SeedShifts' );

--- a/modules/hrm/includes/CLI/Seed/SeedTraining.php
+++ b/modules/hrm/includes/CLI/Seed/SeedTraining.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace WeDevs\ERP\HRM\CLI\Seed;
+
+use WP_CLI;
+
+class SeedTraining extends AbstractSeeder {
+
+    /**
+     * Generate training programs and assign employees (Pro feature).
+     *
+     * ## OPTIONS
+     *
+     * [--count=<count>]
+     * : Number of training programs to create.
+     * ---
+     * default: 10
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp hr seed:training
+     *     wp hr seed:training --count=5
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function __invoke( $args, $assoc_args ) {
+        $this->ensure_admin();
+        $this->suppress_emails();
+
+        if ( ! post_type_exists( 'erp_hr_training' ) ) {
+            WP_CLI::warning( 'Training module not active (post type erp_hr_training not found). Skipping.' );
+            return;
+        }
+
+        $count        = (int) ( $assoc_args['count'] ?? 10 );
+        $topics       = DataProvider::training_topics();
+        $count        = min( $count, count( $topics ) );
+        $employee_ids = $this->get_employee_user_ids();
+
+        if ( empty( $employee_ids ) ) {
+            WP_CLI::error( 'Employees must be created first.' );
+        }
+
+        $progress = $this->progress( 'Creating training programs', $count );
+        $created  = 0;
+
+        $trainers = [ 'Dr. Sarah Mitchell', 'Prof. James Wilson', 'Maria Garcia', 'Robert Chen', 'Lisa Thompson' ];
+        $locations = [ 'Conference Room A', 'Training Center', 'Virtual - Zoom', 'Auditorium', 'Meeting Room 3' ];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $topic = $topics[ $i ];
+
+            // Spread training dates over 2 years.
+            $start = DataProvider::random_date_between(
+                date( 'Y-m-d', strtotime( '-2 years' ) ),
+                date( 'Y-m-d', strtotime( '-1 month' ) )
+            );
+
+            $duration_days = mt_rand( 1, 5 );
+            $end           = date( 'Y-m-d', strtotime( $start . " +{$duration_days} days" ) );
+
+            $post_id = wp_insert_post( [
+                'post_title'   => $topic['title'],
+                'post_content' => $topic['description'],
+                'post_type'    => 'erp_hr_training',
+                'post_status'  => 'publish',
+                'post_date'    => $start . ' 09:00:00',
+            ] );
+
+            if ( is_wp_error( $post_id ) ) {
+                WP_CLI::warning( "Failed to create training '{$topic['title']}': " . $post_id->get_error_message() );
+                $progress->tick();
+                continue;
+            }
+
+            $trainer  = DataProvider::random_element( $trainers );
+            $location = DataProvider::random_element( $locations );
+            $cost     = mt_rand( 500, 5000 );
+            $hours    = $duration_days * 8;
+
+            // Add training meta.
+            update_post_meta( $post_id, '_training_start_date', $start );
+            update_post_meta( $post_id, '_training_end_date', $end );
+            update_post_meta( $post_id, '_training_type', 'classroom' );
+            update_post_meta( $post_id, '_training_status', ( strtotime( $end ) < time() ) ? 'completed' : 'scheduled' );
+
+            // Assign 3-8 random employees.
+            $assign_count      = mt_rand( 3, min( 8, count( $employee_ids ) ) );
+            $assigned_keys     = array_rand( $employee_ids, $assign_count );
+
+            if ( ! is_array( $assigned_keys ) ) {
+                $assigned_keys = [ $assigned_keys ];
+            }
+
+            $completed_emps   = [];
+            $incompleted_emps = [];
+
+            foreach ( $assigned_keys as $key ) {
+                $emp_id  = $employee_ids[ $key ];
+                $is_past = ( strtotime( $end ) < time() );
+
+                // 80% completion rate for past trainings.
+                $completed = $is_past && ( mt_rand( 1, 100 ) <= 80 );
+
+                $training_data = [
+                    'erp_training_completed_date' => $completed ? $end : '',
+                    'erp_training_trainer'        => $trainer,
+                    'erp_trainer_phone'           => sprintf( '555%07d', mt_rand( 1000000, 9999999 ) ),
+                    'erp_training_cost'           => $cost,
+                    'erp_training_credit'         => mt_rand( 1, 4 ),
+                    'erp_training_hours'          => $hours,
+                    'erp_training_note'           => '',
+                    'erp_training_rate'           => round( $cost / $hours, 2 ),
+                    'completed'                   => $completed ? 'yes' : 'no',
+                ];
+
+                $existing = get_user_meta( $emp_id, 'erp_employee_training', true );
+
+                if ( ! is_array( $existing ) ) {
+                    $existing = [];
+                }
+
+                $existing[ $post_id ] = $training_data;
+                update_user_meta( $emp_id, 'erp_employee_training', $existing );
+
+                if ( $completed ) {
+                    $completed_emps[] = $emp_id;
+                } else {
+                    $incompleted_emps[] = $emp_id;
+                }
+            }
+
+            update_post_meta( $post_id, 'erp_training_completed_employee', $completed_emps );
+            update_post_meta( $post_id, 'erp_training_incompleted_employee', $incompleted_emps );
+
+            $created++;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        WP_CLI::success( sprintf( 'Created %d training programs.', $created ) );
+    }
+}
+
+WP_CLI::add_command( 'hr seed:training', __NAMESPACE__ . '\\SeedTraining' );


### PR DESCRIPTION
Introduces a comprehensive set of WP-CLI seed commands for the HRM module, including master orchestration, individual seeders for employees, departments, designations, leave, attendance, assets, announcements, and more. Adds data providers and abstract seeder utilities to support realistic demo data generation and dependencies. Updates CLI command registration and autoloading to support the new seed infrastructure.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
