### PR TITLE
Add OneSignal push notification module

### DIFF
--- a/includes/API/AnnouncementsController.php
+++ b/includes/API/AnnouncementsController.php
@@ -83,6 +83,32 @@ class AnnouncementsController extends REST_Controller {
             ],
             'schema' => [ $this, 'get_public_item_schema' ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/my', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_my_announcements' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return is_user_logged_in();
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/my/(?P<id>[\d]+)', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_my_announcement' ],
+                'args'                => [
+                    'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+                ],
+                'permission_callback' => function ( $request ) {
+                    return is_user_logged_in();
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
     }
 
     /**
@@ -136,6 +162,88 @@ class AnnouncementsController extends REST_Controller {
         }
 
         $item     = $this->prepare_item_for_response( $item, $request );
+        $response = rest_ensure_response( $item );
+
+        return $response;
+    }
+
+    /**
+     * Get announcements for the current logged-in user
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_Error|WP_REST_Response
+     */
+    public function get_my_announcements( $request ) {
+        $current_user_id = get_current_user_id();
+
+        if ( ! $current_user_id ) {
+            return new WP_Error( 'rest_not_authenticated', __( 'User is not authenticated.' ), [ 'status' => 401 ] );
+        }
+
+        $announcement_model = new \WeDevs\ERP\HRM\Models\Announcement();
+        $announcements = $announcement_model->where( 'user_id', $current_user_id )->get();
+
+        $post_ids = $announcements->pluck( 'post_id' )->toArray();
+
+        if ( empty( $post_ids ) ) {
+            return rest_ensure_response( [] );
+        }
+
+        $args = [
+            'post__in'       => $post_ids,
+            'posts_per_page' => $request['per_page'],
+            'offset'         => ( $request['per_page'] * ( $request['page'] - 1 ) ),
+            'post_type'      => 'erp_hr_announcement',
+        ];
+
+        $items = get_posts( $args );
+        $formated_items = [];
+
+        foreach ( $items as $item ) {
+            $item->id         = $item->ID;
+            $data             = $this->prepare_item_for_response( $item, $request );
+            $formated_items[] = $this->prepare_response_for_collection( $data );
+        }
+
+        $response = rest_ensure_response( $formated_items );
+        $response = $this->format_collection_response( $response, $request, \count( $post_ids ) );
+
+        return $response;
+    }
+
+    /**
+     * Get a specific announcement for the current user
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_Error|WP_REST_Response
+     */
+    public function get_my_announcement( $request ) {
+        $current_user_id = get_current_user_id();
+        $announcement_id = (int) $request['id'];
+
+        if ( ! $current_user_id ) {
+            return new WP_Error( 'rest_not_authenticated', __( 'User is not authenticated.' ), [ 'status' => 401 ] );
+        }
+
+        $announcement_model = new \WeDevs\ERP\HRM\Models\Announcement();
+        $announcement = $announcement_model->where( 'user_id', $current_user_id )
+            ->where( 'post_id', $announcement_id )
+            ->first();
+
+        if ( ! $announcement ) {
+            return new WP_Error( 'rest_announcement_not_found', __( 'Announcement not found or you do not have permission to view it.' ), [ 'status' => 404 ] );
+        }
+
+        $item = get_post( $announcement_id );
+
+        if ( empty( $item ) || $item->post_type !== 'erp_hr_announcement' ) {
+            return new WP_Error( 'rest_announcement_invalid_id', __( 'Invalid announcement id.' ), [ 'status' => 404 ] );
+        }
+
+        $item->id = $item->ID;
+        $item = $this->prepare_item_for_response( $item, $request );
         $response = rest_ensure_response( $item );
 
         return $response;

--- a/modules/hrm/HRM.php
+++ b/modules/hrm/HRM.php
@@ -52,6 +52,9 @@ class HRM {
         $this->init_filters();
 
         do_action( 'erp_hrm_loaded' );
+
+        // Bootstrap push notification module.
+        \WeDevs\ERP\HRM\PushNotification\Module::init();
     }
 
     /**

--- a/modules/hrm/includes/API/AnnouncementsController.php
+++ b/modules/hrm/includes/API/AnnouncementsController.php
@@ -76,6 +76,32 @@ class AnnouncementsController extends REST_Controller {
             ],
             'schema' => [ $this, 'get_public_item_schema' ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/my', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_my_announcements' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return is_user_logged_in();
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/my/(?P<id>[\d]+)', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_my_announcement' ],
+                'args'                => [
+                    'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+                ],
+                'permission_callback' => function ( $request ) {
+                    return is_user_logged_in();
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
     }
 
     /**
@@ -129,6 +155,88 @@ class AnnouncementsController extends REST_Controller {
         }
 
         $item     = $this->prepare_item_for_response( $item, $request );
+        $response = rest_ensure_response( $item );
+
+        return $response;
+    }
+
+    /**
+     * Get announcements for the current logged-in user
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_Error|WP_REST_Response
+     */
+    public function get_my_announcements( $request ) {
+        $current_user_id = get_current_user_id();
+
+        if ( ! $current_user_id ) {
+            return new WP_Error( 'rest_not_authenticated', __( 'User is not authenticated.', 'erp' ), [ 'status' => 401 ] );
+        }
+
+        $announcement_model = new \WeDevs\ERP\HRM\Models\Announcement();
+        $announcements = $announcement_model->where( 'user_id', $current_user_id )->get();
+
+        $post_ids = $announcements->pluck( 'post_id' )->toArray();
+
+        if ( empty( $post_ids ) ) {
+            return rest_ensure_response( [] );
+        }
+
+        $args = [
+            'post__in'       => $post_ids,
+            'posts_per_page' => $request['per_page'],
+            'offset'         => ( $request['per_page'] * ( $request['page'] - 1 ) ),
+            'post_type'      => 'erp_hr_announcement',
+        ];
+
+        $items = get_posts( $args );
+        $formated_items = [];
+
+        foreach ( $items as $item ) {
+            $item->id         = $item->ID;
+            $data             = $this->prepare_item_for_response( $item, $request );
+            $formated_items[] = $this->prepare_response_for_collection( $data );
+        }
+
+        $response = rest_ensure_response( $formated_items );
+        $response = $this->format_collection_response( $response, $request, \count( $post_ids ) );
+
+        return $response;
+    }
+
+    /**
+     * Get a specific announcement for the current user
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_Error|WP_REST_Response
+     */
+    public function get_my_announcement( $request ) {
+        $current_user_id = get_current_user_id();
+        $announcement_id = (int) $request['id'];
+
+        if ( ! $current_user_id ) {
+            return new WP_Error( 'rest_not_authenticated', __( 'User is not authenticated.', 'erp' ), [ 'status' => 401 ] );
+        }
+
+        $announcement_model = new \WeDevs\ERP\HRM\Models\Announcement();
+        $announcement = $announcement_model->where( 'user_id', $current_user_id )
+            ->where( 'post_id', $announcement_id )
+            ->first();
+
+        if ( ! $announcement ) {
+            return new WP_Error( 'rest_announcement_not_found', __( 'Announcement not found or you do not have permission to view it.', 'erp' ), [ 'status' => 404 ] );
+        }
+
+        $item = get_post( $announcement_id );
+
+        if ( empty( $item ) || $item->post_type !== 'erp_hr_announcement' ) {
+            return new WP_Error( 'rest_announcement_invalid_id', __( 'Invalid announcement id.', 'erp' ), [ 'status' => 404 ] );
+        }
+
+        $item->id = $item->ID;
+        $item = $this->prepare_item_for_response( $item, $request );
         $response = rest_ensure_response( $item );
 
         return $response;

--- a/modules/hrm/includes/PushNotification/AbstractNotification.php
+++ b/modules/hrm/includes/PushNotification/AbstractNotification.php
@@ -1,0 +1,41 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Abstract base class for push notification providers.
+ *
+ * Provides shared utility methods for all notification implementations.
+ *
+ * @since 1.0.0
+ */
+abstract class AbstractNotification implements NotificationInterface {
+
+    /**
+     * Make an HTTP POST request with a JSON body.
+     *
+     * @since 1.0.0
+     *
+     * @param string $url     The endpoint URL.
+     * @param array  $headers Request headers.
+     * @param array  $payload Request payload (will be JSON-encoded).
+     *
+     * @return array|WP_Error The response or a WP_Error on failure.
+     */
+    protected function post_json( $url, $headers, $payload ) {
+        $args = [
+            'headers' => array_merge(
+                [ 'Content-Type' => 'application/json; charset=utf-8' ],
+                $headers
+            ),
+            'body'    => wp_json_encode( $payload ),
+            'timeout' => 15,
+        ];
+
+        return wp_remote_post( $url, $args );
+    }
+}

--- a/modules/hrm/includes/PushNotification/Module.php
+++ b/modules/hrm/includes/PushNotification/Module.php
@@ -91,6 +91,9 @@ class Module {
         // Announcement hook.
         add_action( 'hr_announcement_insert_assignment', [ $this, 'on_announcement' ], 10, 2 );
 
+        // Holiday hook.
+        add_action( 'erp_hr_new_holiday', [ $this, 'on_new_holiday' ], 10, 2 );
+
         // Add checkbox to announcement creation form.
         add_action( 'hr_announcement_table_last', [ $this, 'announcement_push_checkbox' ] );
     }
@@ -236,6 +239,24 @@ class Module {
     }
 
     /**
+     * Dispatch a push notification to all employees when a holiday is created.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $holiday_id Holiday ID.
+     * @param array $args       Holiday data (title, start, end, etc.).
+     *
+     * @return void
+     */
+    public function on_new_holiday( $holiday_id, $args ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'holiday' ) ) {
+            return;
+        }
+
+        $this->handler->on_new_holiday( $holiday_id, $args );
+    }
+
+    /**
      * Check whether push notifications are enabled for a particular feature.
      *
      * @since 1.0.0
@@ -248,6 +269,7 @@ class Module {
         $option_map = [
             'leave'        => 'erp_push_enable_leave',
             'announcement' => 'erp_push_enable_announcement',
+            'holiday'      => 'erp_push_enable_holiday',
         ];
 
         if ( ! isset( $option_map[ $feature ] ) ) {

--- a/modules/hrm/includes/PushNotification/Module.php
+++ b/modules/hrm/includes/PushNotification/Module.php
@@ -94,6 +94,10 @@ class Module {
         // Holiday hook.
         add_action( 'erp_hr_new_holiday', [ $this, 'on_new_holiday' ], 10, 2 );
 
+        // Birthday hooks (fired per employee by cron, same as birthday wish email).
+        add_action( 'erp_hr_happened_birthday_today', [ $this, 'on_birthday' ],                   10, 1 );
+        add_action( 'erp_hr_happened_birthday_today', [ $this, 'on_birthday_notify_colleagues' ], 20, 1 );
+
         // Add checkbox to announcement creation form.
         add_action( 'hr_announcement_table_last', [ $this, 'announcement_push_checkbox' ] );
     }
@@ -257,6 +261,40 @@ class Module {
     }
 
     /**
+     * Dispatch a birthday push notification to the employee.
+     *
+     * @since 1.0.0
+     *
+     * @param int $user_id WordPress user ID of the birthday employee.
+     *
+     * @return void
+     */
+    public function on_birthday( $user_id ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'birthday' ) ) {
+            return;
+        }
+
+        $this->handler->on_birthday( $user_id );
+    }
+
+    /**
+     * Notify all other employees about their colleague's birthday.
+     *
+     * @since 1.0.0
+     *
+     * @param int $user_id WordPress user ID of the birthday employee.
+     *
+     * @return void
+     */
+    public function on_birthday_notify_colleagues( $user_id ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'birthday_colleagues' ) ) {
+            return;
+        }
+
+        $this->handler->on_birthday_notify_colleagues( $user_id );
+    }
+
+    /**
      * Check whether push notifications are enabled for a particular feature.
      *
      * @since 1.0.0
@@ -270,6 +308,8 @@ class Module {
             'leave'        => 'erp_push_enable_leave',
             'announcement' => 'erp_push_enable_announcement',
             'holiday'      => 'erp_push_enable_holiday',
+            'birthday'            => 'erp_push_enable_birthday',
+            'birthday_colleagues' => 'erp_push_birthday_notify_all',
         ];
 
         if ( ! isset( $option_map[ $feature ] ) ) {

--- a/modules/hrm/includes/PushNotification/Module.php
+++ b/modules/hrm/includes/PushNotification/Module.php
@@ -98,6 +98,9 @@ class Module {
         add_action( 'erp_hr_happened_birthday_today', [ $this, 'on_birthday' ],                   10, 1 );
         add_action( 'erp_hr_happened_birthday_today', [ $this, 'on_birthday_notify_colleagues' ], 20, 1 );
 
+        // Job apply hook.
+        add_action( 'erp_rec_applied_job', [ $this, 'on_job_apply' ], 10, 1 );
+
         // Add checkbox to announcement creation form.
         add_action( 'hr_announcement_table_last', [ $this, 'announcement_push_checkbox' ] );
     }
@@ -278,6 +281,23 @@ class Module {
     }
 
     /**
+     * Dispatch a push notification to HR managers when a new job application is submitted.
+     *
+     * @since 1.0.0
+     *
+     * @param array $data Application data: job_id, applicant_id, stage, exam_detail.
+     *
+     * @return void
+     */
+    public function on_job_apply( $data ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'job_apply' ) ) {
+            return;
+        }
+
+        $this->handler->on_job_apply( $data );
+    }
+
+    /**
      * Notify all other employees about their colleague's birthday.
      *
      * @since 1.0.0
@@ -305,11 +325,12 @@ class Module {
      */
     private function is_push_enabled_for( $feature ) {
         $option_map = [
-            'leave'        => 'erp_push_enable_leave',
-            'announcement' => 'erp_push_enable_announcement',
-            'holiday'      => 'erp_push_enable_holiday',
+            'leave'               => 'erp_push_enable_leave',
+            'announcement'        => 'erp_push_enable_announcement',
+            'holiday'             => 'erp_push_enable_holiday',
             'birthday'            => 'erp_push_enable_birthday',
             'birthday_colleagues' => 'erp_push_birthday_notify_all',
+            'job_apply'           => 'erp_push_enable_job_apply',
         ];
 
         if ( ! isset( $option_map[ $feature ] ) ) {

--- a/modules/hrm/includes/PushNotification/Module.php
+++ b/modules/hrm/includes/PushNotification/Module.php
@@ -1,0 +1,273 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Push Notification module for WP ERP.
+ *
+ * Dispatches OneSignal push notifications for:
+ *   - New leave requests (notifies HR managers)
+ *   - Approved / rejected leave requests (notifies the employee)
+ *   - New HR announcements (notifies assigned employees)
+ *
+ * @since 1.0.0
+ */
+class Module {
+
+    /**
+     * Holds the NotificationHandler instance.
+     *
+     * @var NotificationHandler|null
+     */
+    private $handler;
+
+    /**
+     * Initializes the Module (singleton).
+     *
+     * @since 1.0.0
+     *
+     * @return self
+     */
+    public static function init() {
+        static $instance = false;
+
+        if ( ! $instance ) {
+            $instance = new self();
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
+    private function __construct() {
+        $this->init_handler();
+        $this->init_actions();
+        $this->init_filters();
+    }
+
+    /**
+     * Build the NotificationHandler using the configured OneSignal credentials.
+     *
+     * When credentials are missing the handler stays null and all callbacks
+     * become no-ops.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    private function init_handler() {
+        $app_id       = $this->get_option( 'erp_push_onesignal_app_id' );
+        $rest_api_key = $this->get_option( 'erp_push_onesignal_rest_api_key' );
+
+        if ( empty( $app_id ) || empty( $rest_api_key ) ) {
+            return;
+        }
+
+        $provider      = new OneSignal( $app_id, $rest_api_key );
+        $this->handler = new NotificationHandler( $provider );
+    }
+
+    /**
+     * Register WordPress action hooks.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    private function init_actions() {
+        // Leave request hooks.
+        add_action( 'erp_hr_leave_new',              [ $this, 'on_leave_request_new' ],      10, 2 );
+        add_action( 'erp_hr_leave_request_approved', [ $this, 'on_leave_request_approved' ], 10, 2 );
+        add_action( 'erp_hr_leave_request_reject',   [ $this, 'on_leave_request_rejected' ], 10, 2 );
+
+        // Announcement hook.
+        add_action( 'hr_announcement_insert_assignment', [ $this, 'on_announcement' ], 10, 2 );
+
+        // Add checkbox to announcement creation form.
+        add_action( 'hr_announcement_table_last', [ $this, 'announcement_push_checkbox' ] );
+    }
+
+    /**
+     * Register WordPress filter hooks.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    private function init_filters() {
+        add_filter( 'erp_integration_classes', [ $this, 'add_settings_page' ] );
+    }
+
+    /**
+     * Register the settings integration page.
+     *
+     * @since 1.0.0
+     *
+     * @param array $settings Existing integration settings.
+     *
+     * @return array
+     */
+    public function add_settings_page( $settings ) {
+        $settings['push_notification'] = new Settings();
+
+        return $settings;
+    }
+
+    /**
+     * Add the "Send Push Notification" checkbox to the announcement edit screen.
+     *
+     * @since 1.0.0
+     *
+     * @param \WP_Post $post The current announcement post object.
+     *
+     * @return void
+     */
+    public function announcement_push_checkbox( $post ) {
+        if ( ! $this->is_push_enabled_for( 'announcement' ) ) {
+            return;
+        }
+
+        $push_enabled = get_post_meta( $post->ID, '_announcement_send_push', true );
+        ?>
+        <tr>
+            <th><?php esc_html_e( 'Send Push Notification', 'erp' ); ?></th>
+            <td>
+                <input id="hr-announcement-push-check"
+                       name="hr_announcement_send_push"
+                       type="checkbox"
+                       <?php checked( 'on', $push_enabled ); ?>
+                />
+                &nbsp;
+                <span><?php esc_html_e( 'Check to send push notification', 'erp' ); ?></span>
+            </td>
+        </tr>
+        <?php
+    }
+
+    /**
+     * Persist the push checkbox meta and dispatch on announcement save.
+     *
+     * @since 1.0.0
+     *
+     * @param array $employees Array of employee user IDs.
+     * @param int   $post_id   Announcement post ID.
+     *
+     * @return void
+     */
+    public function on_announcement( $employees, $post_id ) {
+        if ( ! current_user_can( 'manage_erp' ) && ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        // Persist the checkbox value whenever the announcement is saved.
+        $push_enabled = isset( $_REQUEST['hr_announcement_send_push'] ) // phpcs:ignore WordPress.Security.NonceVerification
+            ? sanitize_text_field( wp_unslash( $_REQUEST['hr_announcement_send_push'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+            : '';
+
+        update_post_meta( $post_id, '_announcement_send_push', $push_enabled );
+
+        if ( ! $this->handler ) {
+            return;
+        }
+
+        $this->handler->on_announcement( $employees, $post_id );
+    }
+
+    /**
+     * Dispatch a push notification when a leave request is submitted.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_new( $request_id, $request ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'leave' ) ) {
+            return;
+        }
+
+        $this->handler->on_leave_request_new( $request_id, $request );
+    }
+
+    /**
+     * Dispatch a push notification when a leave request is approved.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_approved( $request_id, $request ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'leave' ) ) {
+            return;
+        }
+
+        $this->handler->on_leave_request_approved( $request_id, $request );
+    }
+
+    /**
+     * Dispatch a push notification when a leave request is rejected.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_rejected( $request_id, $request ) {
+        if ( ! $this->handler || ! $this->is_push_enabled_for( 'leave' ) ) {
+            return;
+        }
+
+        $this->handler->on_leave_request_rejected( $request_id, $request );
+    }
+
+    /**
+     * Check whether push notifications are enabled for a particular feature.
+     *
+     * @since 1.0.0
+     *
+     * @param string $feature Feature key: 'leave' or 'announcement'.
+     *
+     * @return bool
+     */
+    private function is_push_enabled_for( $feature ) {
+        $option_map = [
+            'leave'        => 'erp_push_enable_leave',
+            'announcement' => 'erp_push_enable_announcement',
+        ];
+
+        if ( ! isset( $option_map[ $feature ] ) ) {
+            return false;
+        }
+
+        return 'yes' === $this->get_option( $option_map[ $feature ] );
+    }
+
+    /**
+     * Retrieve a saved push notification option value.
+     *
+     * @since 1.0.0
+     *
+     * @param string $field_id Option field key.
+     * @param mixed  $default  Default value.
+     *
+     * @return mixed
+     */
+    private function get_option( $field_id, $default = '' ) {
+        return erp_get_option( $field_id, Settings::OPTION_KEY, $default );
+    }
+}

--- a/modules/hrm/includes/PushNotification/Module.php
+++ b/modules/hrm/includes/PushNotification/Module.php
@@ -91,8 +91,8 @@ class Module {
         // Announcement hook.
         add_action( 'hr_announcement_insert_assignment', [ $this, 'on_announcement' ], 10, 2 );
 
-        // Holiday hook.
-        add_action( 'erp_hr_new_holiday', [ $this, 'on_new_holiday' ], 10, 2 );
+        // Holiday reminder: runs daily via cron, fires N days before holiday start.
+        add_action( 'erp_daily_scheduled_events', [ $this, 'on_holiday_reminder_check' ] );
 
         // Birthday hooks (fired per employee by cron, same as birthday wish email).
         add_action( 'erp_hr_happened_birthday_today', [ $this, 'on_birthday' ],                   10, 1 );
@@ -246,21 +246,39 @@ class Module {
     }
 
     /**
-     * Dispatch a push notification to all employees when a holiday is created.
+     * Daily cron callback: send holiday push reminders to all employees
+     * the configured number of days before each upcoming holiday.
      *
      * @since 1.0.0
      *
-     * @param int   $holiday_id Holiday ID.
-     * @param array $args       Holiday data (title, start, end, etc.).
-     *
      * @return void
      */
-    public function on_new_holiday( $holiday_id, $args ) {
+    public function on_holiday_reminder_check() {
         if ( ! $this->handler || ! $this->is_push_enabled_for( 'holiday' ) ) {
             return;
         }
 
-        $this->handler->on_new_holiday( $holiday_id, $args );
+        $days_before = $this->get_holiday_reminder_days();
+        $this->handler->on_holiday_reminder( $days_before );
+    }
+
+    /**
+     * Resolve the configured number of days before a holiday to send the reminder.
+     *
+     * Custom days field takes priority over the preset dropdown.
+     *
+     * @since 1.0.0
+     *
+     * @return int Always >= 1.
+     */
+    private function get_holiday_reminder_days() {
+        $custom = absint( $this->get_option( 'erp_push_holiday_custom_days', '' ) );
+        if ( $custom > 0 ) {
+            return $custom;
+        }
+
+        $preset = absint( $this->get_option( 'erp_push_holiday_days_before', 1 ) );
+        return max( 1, $preset );
     }
 
     /**

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -244,6 +244,87 @@ class NotificationHandler {
     }
 
     /**
+     * Send a birthday push notification to the employee.
+     *
+     * Mirrors erp_hr_send_birthday_wish_email() which is fired on the same hook.
+     *
+     * @since 1.0.0
+     *
+     * @param int $user_id WordPress user ID of the birthday employee.
+     *
+     * @return void
+     */
+    public function on_birthday( $user_id ) {
+        $user_id = absint( $user_id );
+
+        if ( ! $user_id ) {
+            return;
+        }
+
+        $name = $this->get_employee_name( $user_id );
+
+        $this->notification->send(
+            [ $user_id ],
+            __( 'Happy Birthday!', 'erp' ),
+            ! empty( $name )
+                ? sprintf( __( 'Wishing you a very happy birthday, %s!', 'erp' ), $name )
+                : __( 'Wishing you a very happy birthday!', 'erp' ),
+            [
+                'type'    => 'birthday',
+                'user_id' => $user_id,
+            ]
+        );
+    }
+
+    /**
+     * Notify all other employees about their colleague's birthday.
+     *
+     * @since 1.0.0
+     *
+     * @param int $user_id WordPress user ID of the birthday employee.
+     *
+     * @return void
+     */
+    public function on_birthday_notify_colleagues( $user_id ) {
+        $user_id = absint( $user_id );
+
+        if ( ! $user_id ) {
+            return;
+        }
+
+        $name = $this->get_employee_name( $user_id );
+
+        if ( empty( $name ) ) {
+            return;
+        }
+
+        $employees = erp_hr_get_employees( [ 'number' => -1, 'no_object' => true ] );
+
+        if ( empty( $employees ) ) {
+            return;
+        }
+
+        $other_ids = array_values( array_filter( array_map( function( $emp ) use ( $user_id ) {
+            $id = isset( $emp->user_id ) ? absint( $emp->user_id ) : 0;
+            return ( $id && $id !== $user_id ) ? $id : 0;
+        }, $employees ) ) );
+
+        if ( empty( $other_ids ) ) {
+            return;
+        }
+
+        $this->notification->send(
+            $other_ids,
+            __( 'Birthday Today!', 'erp' ),
+            sprintf( __( "Today is %s's birthday. Wish them well!", 'erp' ), $name ),
+            [
+                'type'    => 'birthday_colleague',
+                'user_id' => $user_id,
+            ]
+        );
+    }
+
+    /**
      * Retrieve the display name for an employee.
      *
      * @since 1.0.0

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -1,0 +1,222 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Orchestrates push notifications for WP ERP events.
+ *
+ * @since 1.0.0
+ */
+class NotificationHandler {
+
+    /**
+     * The push notification provider.
+     *
+     * @var NotificationInterface
+     */
+    private $notification;
+
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     *
+     * @param NotificationInterface $notification Push notification provider instance.
+     */
+    public function __construct( NotificationInterface $notification ) {
+        $this->notification = $notification;
+    }
+
+    /**
+     * Notify HR managers when an employee submits a new leave request.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_new( $request_id, $request ) {
+        if ( empty( $request_id ) || empty( $request ) ) {
+            return;
+        }
+
+        $employee_id   = isset( $request['user_id'] ) ? absint( $request['user_id'] ) : 0;
+        $employee_name = $this->get_employee_name( $employee_id );
+
+        $title   = __( 'New Leave Request', 'erp' );
+        $message = sprintf( __( '%s has submitted a new leave request.', 'erp' ), $employee_name );
+
+        $manager_ids = $this->get_hr_manager_ids();
+
+        if ( empty( $manager_ids ) ) {
+            return;
+        }
+
+        $this->notification->send(
+            $manager_ids,
+            $title,
+            $message,
+            [
+                'type'             => 'leave_request_new',
+                'leave_request_id' => absint( $request_id ),
+            ]
+        );
+    }
+
+    /**
+     * Notify the employee when their leave request is approved.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_approved( $request_id, $request ) {
+        if ( empty( $request_id ) || empty( $request ) ) {
+            return;
+        }
+
+        $employee_id = isset( $request['user_id'] ) ? absint( $request['user_id'] ) : 0;
+
+        if ( ! $employee_id ) {
+            return;
+        }
+
+        $title   = __( 'Leave Request Approved', 'erp' );
+        $message = __( 'Your leave request has been approved.', 'erp' );
+
+        $this->notification->send(
+            [ $employee_id ],
+            $title,
+            $message,
+            [
+                'type'             => 'leave_request_approved',
+                'leave_request_id' => absint( $request_id ),
+            ]
+        );
+    }
+
+    /**
+     * Notify the employee when their leave request is rejected.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $request_id Leave request ID.
+     * @param array $request    Leave request data array.
+     *
+     * @return void
+     */
+    public function on_leave_request_rejected( $request_id, $request ) {
+        if ( empty( $request_id ) || empty( $request ) ) {
+            return;
+        }
+
+        $employee_id = isset( $request['user_id'] ) ? absint( $request['user_id'] ) : 0;
+
+        if ( ! $employee_id ) {
+            return;
+        }
+
+        $title   = __( 'Leave Request Rejected', 'erp' );
+        $message = __( 'Your leave request has been rejected.', 'erp' );
+
+        $this->notification->send(
+            [ $employee_id ],
+            $title,
+            $message,
+            [
+                'type'             => 'leave_request_rejected',
+                'leave_request_id' => absint( $request_id ),
+            ]
+        );
+    }
+
+    /**
+     * Send a push notification to employees when an announcement is published.
+     *
+     * @since 1.0.0
+     *
+     * @param array $employees Array of employee user IDs.
+     * @param int   $post_id   Announcement post ID.
+     *
+     * @return void
+     */
+    public function on_announcement( $employees, $post_id ) {
+        $push_enabled = get_post_meta( $post_id, '_announcement_send_push', true );
+
+        if ( 'on' !== $push_enabled ) {
+            return;
+        }
+
+        $post = get_post( $post_id );
+
+        if ( empty( $post ) ) {
+            return;
+        }
+
+        $title   = get_the_title( $post );
+        $message = wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
+
+        if ( empty( $employees ) ) {
+            return;
+        }
+
+        $user_ids = array_map( 'absint', (array) $employees );
+
+        $this->notification->send(
+            $user_ids,
+            $title,
+            $message,
+            [
+                'type'            => 'announcement',
+                'post_id'         => absint( $post_id ),
+                'announcement_id' => absint( $post_id ),
+            ]
+        );
+    }
+
+    /**
+     * Retrieve the display name for an employee.
+     *
+     * @since 1.0.0
+     *
+     * @param int $employee_id WordPress user ID.
+     *
+     * @return string
+     */
+    private function get_employee_name( $employee_id ) {
+        if ( ! $employee_id ) {
+            return '';
+        }
+
+        $user = get_userdata( $employee_id );
+
+        return $user ? $user->display_name : '';
+    }
+
+    /**
+     * Get the WordPress user IDs of all HR managers.
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    private function get_hr_manager_ids() {
+        $managers = get_users( [ 'role__in' => [ 'erp_hr_manager' ] ] );
+        $ids      = [];
+
+        foreach ( $managers as $manager ) {
+            $ids[] = absint( $manager->ID );
+        }
+
+        return array_values( $ids );
+    }
+}

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -184,6 +184,66 @@ class NotificationHandler {
     }
 
     /**
+     * Send a push notification to all employees when a new holiday is created.
+     *
+     * Mirrors the behaviour of erp_hr_holiday_reminder_to_employees() which
+     * sends an email to every employee for upcoming holidays.
+     *
+     * @since 1.0.0
+     *
+     * @param int   $holiday_id Holiday ID.
+     * @param array $args       Holiday data: title, start, end, etc.
+     *
+     * @return void
+     */
+    public function on_new_holiday( $holiday_id, $args ) {
+        if ( empty( $holiday_id ) || empty( $args['title'] ) ) {
+            return;
+        }
+
+        $title = ! empty( $args['title'] ) ? sanitize_text_field( $args['title'] ) : __( 'New Holiday', 'erp' );
+
+        $holiday_start = isset( $args['start'] ) ? erp_current_datetime()->modify( $args['start'] ) : null;
+        $holiday_end   = isset( $args['end'] )   ? erp_current_datetime()->modify( $args['end'] )   : null;
+
+        if ( $holiday_start && $holiday_end ) {
+            $day_diff = $holiday_start->diff( $holiday_end )->days;
+
+            if ( 0 === $day_diff ) {
+                $message = $holiday_start->format( 'l, F j, Y' );
+            } else {
+                $message = $holiday_start->format( 'l, F j, Y' ) . ' – ' . $holiday_end->format( 'l, F j, Y' );
+            }
+        } else {
+            $message = __( 'Holiday', 'erp' );
+        }
+
+        $employees = erp_hr_get_employees( [ 'number' => -1, 'no_object' => true ] );
+
+        if ( empty( $employees ) ) {
+            return;
+        }
+
+        $user_ids = array_values( array_filter( array_map( function( $emp ) {
+            return isset( $emp->user_id ) ? absint( $emp->user_id ) : 0;
+        }, $employees ) ) );
+
+        if ( empty( $user_ids ) ) {
+            return;
+        }
+
+        $this->notification->send(
+            $user_ids,
+            $title,
+            $message,
+            [
+                'type'       => 'holiday',
+                'holiday_id' => absint( $holiday_id ),
+            ]
+        );
+    }
+
+    /**
      * Retrieve the display name for an employee.
      *
      * @since 1.0.0

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -184,38 +184,29 @@ class NotificationHandler {
     }
 
     /**
-     * Send a push notification to all employees when a new holiday is created.
+     * Send push reminders for holidays starting in exactly $days_before days.
      *
-     * Mirrors the behaviour of erp_hr_holiday_reminder_to_employees() which
-     * sends an email to every employee for upcoming holidays.
+     * Called daily by cron via Module::on_holiday_reminder_check().
+     * Mirrors the email pattern in erp_hr_holiday_reminder_to_employees().
      *
      * @since 1.0.0
      *
-     * @param int   $holiday_id Holiday ID.
-     * @param array $args       Holiday data: title, start, end, etc.
+     * @param int $days_before Number of days before the holiday start to send the reminder.
      *
      * @return void
      */
-    public function on_new_holiday( $holiday_id, $args ) {
-        if ( empty( $holiday_id ) || empty( $args['title'] ) ) {
+    public function on_holiday_reminder( $days_before ) {
+        $days_before = max( 1, absint( $days_before ) );
+
+        $target_day = erp_current_datetime()->modify( "+{$days_before} days" )->format( 'Y-m-d' );
+
+        $holidays = ( new \WeDevs\ERP\HRM\Models\LeaveHoliday() )
+            ->whereDate( 'start', $target_day )
+            ->get()
+            ->toArray();
+
+        if ( empty( $holidays ) ) {
             return;
-        }
-
-        $title = ! empty( $args['title'] ) ? sanitize_text_field( $args['title'] ) : __( 'New Holiday', 'erp' );
-
-        $holiday_start = isset( $args['start'] ) ? erp_current_datetime()->modify( $args['start'] ) : null;
-        $holiday_end   = isset( $args['end'] )   ? erp_current_datetime()->modify( $args['end'] )   : null;
-
-        if ( $holiday_start && $holiday_end ) {
-            $day_diff = $holiday_start->diff( $holiday_end )->days;
-
-            if ( 0 === $day_diff ) {
-                $message = $holiday_start->format( 'l, F j, Y' );
-            } else {
-                $message = $holiday_start->format( 'l, F j, Y' ) . ' – ' . $holiday_end->format( 'l, F j, Y' );
-            }
-        } else {
-            $message = __( 'Holiday', 'erp' );
         }
 
         $employees = erp_hr_get_employees( [ 'number' => -1, 'no_object' => true ] );
@@ -232,15 +223,35 @@ class NotificationHandler {
             return;
         }
 
-        $this->notification->send(
-            $user_ids,
-            $title,
-            $message,
-            [
-                'type'       => 'holiday',
-                'holiday_id' => absint( $holiday_id ),
-            ]
-        );
+        foreach ( $holidays as $holiday ) {
+            $title = ! empty( $holiday['title'] )
+                ? sanitize_text_field( $holiday['title'] )
+                : __( 'Upcoming Holiday', 'erp' );
+
+            $holiday_start = erp_current_datetime()->modify( $holiday['start'] );
+            $holiday_end   = erp_current_datetime()->modify( $holiday['end'] );
+            $day_diff      = $holiday_start->diff( $holiday_end )->days;
+
+            if ( 0 === $day_diff ) {
+                $date_str = $holiday_start->format( 'l, F j, Y' );
+            } else {
+                $date_str = $holiday_start->format( 'l, F j, Y' ) . ' – ' . $holiday_end->format( 'l, F j, Y' );
+            }
+
+            $message = 1 === $days_before
+                ? sprintf( __( 'Reminder: %s is tomorrow (%s).', 'erp' ), $title, $date_str )
+                : sprintf( __( 'Reminder: %s is in %d days (%s).', 'erp' ), $title, $days_before, $date_str );
+
+            $this->notification->send(
+                $user_ids,
+                $title,
+                $message,
+                [
+                    'type'       => 'holiday_reminder',
+                    'holiday_id' => absint( $holiday['id'] ),
+                ]
+            );
+        }
     }
 
     /**

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -385,6 +385,7 @@ class NotificationHandler {
                 'type'        => 'job_apply',
                 'job_id'      => $job_id,
                 'applicant_id' => $applicant_id,
+                'application_id' => isset( $data['application_id'] ) ? absint( $data['application_id'] ) : 0,
             ]
         );
     }

--- a/modules/hrm/includes/PushNotification/NotificationHandler.php
+++ b/modules/hrm/includes/PushNotification/NotificationHandler.php
@@ -325,6 +325,60 @@ class NotificationHandler {
     }
 
     /**
+     * Notify HR managers when a new job application is submitted.
+     *
+     * @since 1.0.0
+     *
+     * @param array $data Application data: job_id, applicant_id, stage, exam_detail.
+     *
+     * @return void
+     */
+    public function on_job_apply( $data ) {
+        if ( empty( $data['job_id'] ) || empty( $data['applicant_id'] ) ) {
+            return;
+        }
+
+        $job_id      = absint( $data['job_id'] );
+        $applicant_id = absint( $data['applicant_id'] );
+
+        $job_title = get_the_title( $job_id );
+
+        global $wpdb;
+        $applicant = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT first_name, last_name FROM {$wpdb->prefix}erp_peoples WHERE id = %d",
+                $applicant_id
+            )
+        );
+
+        $applicant_name = $applicant
+            ? trim( $applicant->first_name . ' ' . $applicant->last_name )
+            : __( 'A new applicant', 'erp' );
+
+        $title   = __( 'New Job Application', 'erp' );
+        $message = $job_title
+            ? sprintf( __( '%1$s has applied for %2$s.', 'erp' ), $applicant_name, $job_title )
+            : sprintf( __( '%s has submitted a new job application.', 'erp' ), $applicant_name );
+
+        $manager_ids = $this->get_hr_manager_ids();
+
+        if ( empty( $manager_ids ) ) {
+            return;
+        }
+
+        $this->notification->send(
+            $manager_ids,
+            $title,
+            $message,
+            [
+                'type'        => 'job_apply',
+                'job_id'      => $job_id,
+                'applicant_id' => $applicant_id,
+            ]
+        );
+    }
+
+    /**
      * Retrieve the display name for an employee.
      *
      * @since 1.0.0

--- a/modules/hrm/includes/PushNotification/NotificationInterface.php
+++ b/modules/hrm/includes/PushNotification/NotificationInterface.php
@@ -1,0 +1,46 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Interface for push notification providers.
+ *
+ * Implementing this interface allows new notification providers to be
+ * added without modifying existing code (Open/Closed Principle).
+ *
+ * @since 1.0.0
+ */
+interface NotificationInterface {
+
+    /**
+     * Send a push notification to specific users by their external IDs.
+     *
+     * @since 1.0.0
+     *
+     * @param array  $user_ids Array of external user IDs to target.
+     * @param string $title    Notification title.
+     * @param string $message  Notification message body.
+     * @param array  $data     Optional additional data payload.
+     *
+     * @return array|WP_Error  Response array on success, WP_Error on failure.
+     */
+    public function send( $user_ids, $title, $message, $data = [] );
+
+    /**
+     * Send a push notification to all users in a named segment.
+     *
+     * @since 1.0.0
+     *
+     * @param string $segment Segment name (e.g. 'All', 'Subscribed Users').
+     * @param string $title   Notification title.
+     * @param string $message Notification message body.
+     * @param array  $data    Optional additional data payload.
+     *
+     * @return array|WP_Error Response array on success, WP_Error on failure.
+     */
+    public function send_to_segment( $segment, $title, $message, $data = [] );
+}

--- a/modules/hrm/includes/PushNotification/OneSignal.php
+++ b/modules/hrm/includes/PushNotification/OneSignal.php
@@ -1,0 +1,154 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * OneSignal push notification provider.
+ *
+ * Implements the NotificationInterface using the OneSignal REST API v1.
+ * Uses external_id aliases (not the deprecated player-based system) to
+ * address individual subscribers, and named segments for bulk delivery.
+ *
+ * @see https://documentation.onesignal.com/reference/create-notification
+ *
+ * @since 1.0.0
+ */
+class OneSignal extends AbstractNotification {
+
+    /**
+     * OneSignal REST API base URL.
+     *
+     * @var string
+     */
+    const API_URL = 'https://api.onesignal.com/notifications?c=push';
+
+    /**
+     * OneSignal App ID.
+     *
+     * @var string
+     */
+    private $app_id;
+
+    /**
+     * OneSignal REST API key.
+     *
+     * @var string
+     */
+    private $rest_api_key;
+
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     *
+     * @param string $app_id       OneSignal Application ID.
+     * @param string $rest_api_key OneSignal REST API key.
+     */
+    public function __construct( $app_id, $rest_api_key ) {
+        $this->app_id       = $app_id;
+        $this->rest_api_key = $rest_api_key;
+    }
+
+    /**
+     * Send a push notification to specific users by their external IDs.
+     *
+     * @since 1.0.0
+     *
+     * @param array  $user_ids Array of external user IDs.
+     * @param string $title    Notification title.
+     * @param string $message  Notification message body.
+     * @param array  $data     Optional additional key/value data payload.
+     *
+     * @return array|WP_Error
+     */
+    public function send( $user_ids, $title, $message, $data = [] ) {
+        if ( empty( $user_ids ) ) {
+            return new \WP_Error( 'no_recipients', __( 'No recipients specified.', 'erp' ) );
+        }
+
+        // Cast each ID to string as required by the OneSignal aliases API.
+        $external_ids = array_values( array_map( 'strval', $user_ids ) );
+
+        $payload = [
+            'app_id'          => $this->app_id,
+            'target_channel'  => 'push',
+            'headings'        => [ 'en' => $title ],
+            'contents'        => [ 'en' => $message ],
+            'include_aliases' => [ 'external_id' => $external_ids ],
+        ];
+
+        if ( ! empty( $data ) ) {
+            $payload['data'] = $data;
+        }
+
+        return $this->dispatch( $payload );
+    }
+
+    /**
+     * Send a push notification to all subscribers in a named segment.
+     *
+     * @since 1.0.0
+     *
+     * @param string $segment Segment name (e.g. 'All', 'Subscribed Users').
+     * @param string $title   Notification title.
+     * @param string $message Notification message body.
+     * @param array  $data    Optional additional key/value data payload.
+     *
+     * @return array|WP_Error
+     */
+    public function send_to_segment( $segment, $title, $message, $data = [] ) {
+        if ( empty( $segment ) ) {
+            return new \WP_Error( 'no_segment', __( 'No segment specified.', 'erp' ) );
+        }
+
+        $payload = [
+            'app_id'            => $this->app_id,
+            'target_channel'    => 'push',
+            'headings'          => [ 'en' => $title ],
+            'contents'          => [ 'en' => $message ],
+            'included_segments' => [ $segment ],
+        ];
+
+        if ( ! empty( $data ) ) {
+            $payload['data'] = $data;
+        }
+
+        return $this->dispatch( $payload );
+    }
+
+    /**
+     * Execute the HTTP POST request to the OneSignal notifications endpoint.
+     *
+     * @since 1.0.0
+     *
+     * @param array $payload The fully-assembled notification payload.
+     *
+     * @return array|WP_Error
+     */
+    private function dispatch( $payload ) {
+        $headers = [
+            'Authorization' => $this->rest_api_key,
+        ];
+
+        $response = $this->post_json( self::API_URL, $headers, $payload );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $status_code = wp_remote_retrieve_response_code( $response );
+        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( $status_code >= 400 ) {
+            $error_message = isset( $body['errors'][0] ) ? $body['errors'][0] : __( 'Unknown OneSignal API error.', 'erp' );
+
+            return new \WP_Error( 'onesignal_api_error', $error_message, [ 'status' => $status_code ] );
+        }
+
+        return $body;
+    }
+}

--- a/modules/hrm/includes/PushNotification/Settings.php
+++ b/modules/hrm/includes/PushNotification/Settings.php
@@ -102,10 +102,29 @@ class Settings extends Integration {
                 'default' => '',
             ],
             [
-                'title'   => __( 'Enable for Holidays', 'erp' ),
+                'title'   => __( 'Enable Holiday Reminders', 'erp' ),
                 'type'    => 'checkbox',
                 'id'      => 'erp_push_enable_holiday',
-                'desc'    => __( 'Send push notifications to all employees when a new holiday is created.', 'erp' ),
+                'desc'    => __( 'Send push notifications to all employees before an upcoming holiday.', 'erp' ),
+                'default' => '',
+            ],
+            [
+                'title'   => __( 'Holiday Reminder — Days Before', 'erp' ),
+                'type'    => 'select',
+                'id'      => 'erp_push_holiday_days_before',
+                'desc'    => __( 'Send the reminder this many days before the holiday. Choose a preset or enter a custom value below.', 'erp' ),
+                'default' => '1',
+                'options' => [
+                    '1' => __( '1 day before', 'erp' ),
+                    '3' => __( '3 days before', 'erp' ),
+                    '7' => __( '7 days before', 'erp' ),
+                ],
+            ],
+            [
+                'title'   => __( 'Holiday Reminder — Custom Days (overrides preset)', 'erp' ),
+                'type'    => 'text',
+                'id'      => 'erp_push_holiday_custom_days',
+                'desc'    => __( 'Enter a whole number to override the preset above (e.g. 5 = 5 days before). Leave blank to use the preset.', 'erp' ),
                 'default' => '',
             ],
             [

--- a/modules/hrm/includes/PushNotification/Settings.php
+++ b/modules/hrm/includes/PushNotification/Settings.php
@@ -101,6 +101,13 @@ class Settings extends Integration {
                 'desc'    => __( 'Send push notifications when a new announcement is published.', 'erp' ),
                 'default' => '',
             ],
+            [
+                'title'   => __( 'Enable for Holidays', 'erp' ),
+                'type'    => 'checkbox',
+                'id'      => 'erp_push_enable_holiday',
+                'desc'    => __( 'Send push notifications to all employees when a new holiday is created.', 'erp' ),
+                'default' => '',
+            ],
         ];
     }
 

--- a/modules/hrm/includes/PushNotification/Settings.php
+++ b/modules/hrm/includes/PushNotification/Settings.php
@@ -108,6 +108,20 @@ class Settings extends Integration {
                 'desc'    => __( 'Send push notifications to all employees when a new holiday is created.', 'erp' ),
                 'default' => '',
             ],
+            [
+                'title'   => __( 'Enable for Birthdays', 'erp' ),
+                'type'    => 'checkbox',
+                'id'      => 'erp_push_enable_birthday',
+                'desc'    => __( 'Send a birthday push notification to the employee on their birthday.', 'erp' ),
+                'default' => '',
+            ],
+            [
+                'title'   => __( 'Notify All Employees on Birthday', 'erp' ),
+                'type'    => 'checkbox',
+                'id'      => 'erp_push_birthday_notify_all',
+                'desc'    => __( 'Also notify all other employees about their colleague\'s birthday.', 'erp' ),
+                'default' => '',
+            ],
         ];
     }
 

--- a/modules/hrm/includes/PushNotification/Settings.php
+++ b/modules/hrm/includes/PushNotification/Settings.php
@@ -1,0 +1,131 @@
+<?php
+namespace WeDevs\ERP\HRM\PushNotification;
+
+use WeDevs\ERP\Integration;
+
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Push Notification settings page.
+ *
+ * Registers the OneSignal configuration fields under the ERP Integrations tab.
+ *
+ * @since 1.0.0
+ */
+class Settings extends Integration {
+
+    /**
+     * Option group key used to retrieve saved values.
+     *
+     * @var string
+     */
+    const OPTION_KEY = 'erp_integration_settings_erp-push-notification';
+
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
+    public function __construct() {
+        $this->id          = 'erp-push-notification';
+        $this->title       = __( 'Push Notification', 'erp' );
+        $this->description = __( 'Send push notifications via OneSignal.', 'erp' );
+
+        $this->init_settings();
+        parent::__construct();
+    }
+
+    /**
+     * Return the tab title.
+     *
+     * @since 1.0.0
+     *
+     * @return string
+     */
+    public function get_title() {
+        return $this->title;
+    }
+
+    /**
+     * Return the tab description.
+     *
+     * @since 1.0.0
+     *
+     * @return string
+     */
+    public function get_description() {
+        return $this->description;
+    }
+
+    /**
+     * Initialize form fields.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    public function init_settings() {
+        $this->form_fields = [
+            [
+                'title' => __( 'OneSignal', 'erp' ),
+                'type'  => 'title',
+            ],
+            [
+                'title'   => __( 'App ID', 'erp' ),
+                'type'    => 'text',
+                'id'      => 'erp_push_onesignal_app_id',
+                'desc'    => __( 'Your OneSignal Application ID.', 'erp' ),
+                'default' => '',
+            ],
+            [
+                'title'   => __( 'REST API Key', 'erp' ),
+                'type'    => 'text',
+                'id'      => 'erp_push_onesignal_rest_api_key',
+                'desc'    => __( 'Your OneSignal REST API Key.', 'erp' ),
+                'default' => '',
+            ],
+            [
+                'title'   => __( 'Enable for Leave Requests', 'erp' ),
+                'type'    => 'checkbox',
+                'id'      => 'erp_push_enable_leave',
+                'desc'    => __( 'Send push notifications for leave request events.', 'erp' ),
+                'default' => '',
+            ],
+            [
+                'title'   => __( 'Enable for Announcements', 'erp' ),
+                'type'    => 'checkbox',
+                'id'      => 'erp_push_enable_announcement',
+                'desc'    => __( 'Send push notifications when a new announcement is published.', 'erp' ),
+                'default' => '',
+            ],
+        ];
+    }
+
+    /**
+     * Retrieve the persisted value for a specific field.
+     *
+     * @since 1.0.0
+     *
+     * @param string $field_id Field option key.
+     * @param mixed  $default  Default value when the option is not set.
+     *
+     * @return mixed
+     */
+    public function get_option( $field_id, $default = '' ) {
+        return erp_get_option( $field_id, self::OPTION_KEY, $default );
+    }
+
+    /**
+     * Return the option ID used to persist settings.
+     *
+     * @since 1.0.0
+     *
+     * @return string
+     */
+    public function get_option_id() {
+        return self::OPTION_KEY;
+    }
+}

--- a/modules/hrm/includes/PushNotification/Settings.php
+++ b/modules/hrm/includes/PushNotification/Settings.php
@@ -123,6 +123,18 @@ class Settings extends Integration {
                 'default' => '',
             ],
         ];
+        // if pro version is active, add job apply notification settings
+        if( defined( 'ERP_PRO_PLUGIN_VERSION' ) ) {
+            $this->form_fields = array_merge( $this->form_fields, [
+                [
+                    'title'   => __( 'Enable for Job Applications', 'erp' ),
+                    'type'    => 'checkbox',
+                    'id'      => 'erp_push_enable_job_apply',
+                    'desc'    => __( 'Send push notifications to HR when a new job application is submitted.', 'erp' ),
+                    'default' => '',
+                ],
+            ] );
+        }
     }
 
     /**

--- a/modules/hrm/views/push-notification/settings.php
+++ b/modules/hrm/views/push-notification/settings.php
@@ -1,0 +1,62 @@
+<?php
+// don't call the file directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$settings = new \WeDevs\ERP\HRM\PushNotification\Settings();
+?>
+<div class="erp-push-notification-settings">
+    <form method="post" action="options.php">
+        <?php settings_fields( 'erp_integration_settings_erp-push-notification' ); ?>
+        <table class="form-table">
+            <tbody>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'OneSignal App ID', 'erp' ); ?></th>
+                    <td>
+                        <input type="text"
+                               name="erp_integration_settings_erp-push-notification[erp_push_onesignal_app_id]"
+                               value="<?php echo esc_attr( $settings->get_option( 'erp_push_onesignal_app_id' ) ); ?>"
+                               class="regular-text"
+                        />
+                        <p class="description"><?php esc_html_e( 'Your OneSignal Application ID.', 'erp' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'REST API Key', 'erp' ); ?></th>
+                    <td>
+                        <input type="text"
+                               name="erp_integration_settings_erp-push-notification[erp_push_onesignal_rest_api_key]"
+                               value="<?php echo esc_attr( $settings->get_option( 'erp_push_onesignal_rest_api_key' ) ); ?>"
+                               class="regular-text"
+                        />
+                        <p class="description"><?php esc_html_e( 'Your OneSignal REST API Key.', 'erp' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Enable for Leave Requests', 'erp' ); ?></th>
+                    <td>
+                        <input type="checkbox"
+                               name="erp_integration_settings_erp-push-notification[erp_push_enable_leave]"
+                               value="yes"
+                               <?php checked( 'yes', $settings->get_option( 'erp_push_enable_leave' ) ); ?>
+                        />
+                        <label><?php esc_html_e( 'Send push notifications for leave request events.', 'erp' ); ?></label>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Enable for Announcements', 'erp' ); ?></th>
+                    <td>
+                        <input type="checkbox"
+                               name="erp_integration_settings_erp-push-notification[erp_push_enable_announcement]"
+                               value="yes"
+                               <?php checked( 'yes', $settings->get_option( 'erp_push_enable_announcement' ) ); ?>
+                        />
+                        <label><?php esc_html_e( 'Send push notifications when a new announcement is published.', 'erp' ); ?></label>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>


### PR DESCRIPTION
Bootstrap a new HRM PushNotification module and integrate OneSignal support. Adds a Module that hooks into leave and announcement events, registers a settings integration and an announcement "Send Push Notification" checkbox, and only initializes the handler when OneSignal credentials are configured. Implements NotificationInterface and an AbstractNotification helper, a OneSignal provider that posts JSON to the OneSignal API, a NotificationHandler to orchestrate messages for new/approved/rejected leave and announcements, and an admin settings view for App ID, REST API Key and feature toggles. Also wires Module::init() into HRM startup.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
closes https://github.com/wp-erp/erp-pro/issues/461, https://github.com/wp-erp/erp-pro/issues/473, https://github.com/wp-erp/erp-pro/issues/465, https://github.com/wp-erp/erp-pro/issues/466, https://github.com/wp-erp/erp-pro/issues/474