### PR TITLE
Include Recruitment\Emails in HRM

### DIFF
--- a/includes/Settings/Ajax.php
+++ b/includes/Settings/Ajax.php
@@ -186,6 +186,7 @@ class Ajax {
 				false !== strpos( get_class( $email ), 'HRM' ) ||
 				false !== strpos( get_class( $email ), 'ERP_Document' ) ||
 				false !== strpos( get_class( $email ), 'ERP_Recruitment' ) ||
+				false !== strpos( get_class( $email ), 'Recruitment\\Emails' ) ||
 				false !== strpos( get_class( $email ), 'Training' )
 			) {
 				$emails['hrm'][] = $email_data;

--- a/includes/Settings/Email.php
+++ b/includes/Settings/Email.php
@@ -478,6 +478,7 @@ class Email extends Template {
 							false !== strpos( get_class( $email ), 'HRM' ) ||
 							false !== strpos( get_class( $email ), 'ERP_Document' ) ||
 							false !== strpos( get_class( $email ), 'ERP_Recruitment' ) ||
+							false !== strpos( get_class( $email ), 'Recruitment\\Emails' ) ||
 							false !== strpos( get_class( $email ), 'Training' )
 						) :
 							$tr_class = 'hrm';


### PR DESCRIPTION
Add a class-name check for 'Recruitment\\Emails' in includes/Settings/Ajax.php and includes/Settings/Email.php so classes from the Recruitment namespace are treated as HRM. This ensures recruitment-related email classes are included in the hrm list and receive the same tr_class/styling as other HRM email templates.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
fixes https://github.com/wp-erp/erp-pro/issues/254