### PR TITLE
Enable only HR module by default for new installations

### DIFF
--- a/includes/WeDevsERPInstaller.php
+++ b/includes/WeDevsERPInstaller.php
@@ -2153,22 +2153,6 @@ Account Manager
                 'callback'    => '\WeDevs\ERP\HRM\HRM',
                 'modules'     => apply_filters( 'erp_hr_modules', [] ),
             ],
-
-            'crm' => [
-                'title'       => __( 'CR Management', 'erp' ),
-                'slug'        => 'erp-crm',
-                'description' => __( 'Customer Relationship Management', 'erp' ),
-                'callback'    => '\WeDevs\ERP\CRM\CRM',
-                'modules'     => apply_filters( 'erp_crm_modules', [] ),
-            ],
-
-            'accounting' => [
-                'title'       => __( 'Accounting Management', 'erp' ),
-                'slug'        => 'erp-accounting',
-                'description' => __( 'Accounting Management', 'erp' ),
-                'callback'    => '\WeDevs\ERP\Accounting\Accounting',
-                'modules'     => apply_filters( 'erp_accounting_modules', [] ),
-            ],
         ];
 
         update_option( 'erp_modules', $default );


### PR DESCRIPTION
CRM and Accounting modules are no longer pre-enabled on fresh installs. Existing installations are unaffected.

https://github.com/wp-erp/erp-pro/issues/505