### PR TITLE
fix: duplicate payment bug

### DIFF
--- a/modules/accounting/assets/src/admin/components/rec-payment/RecPaymentCreate.vue
+++ b/modules/accounting/assets/src/admin/components/rec-payment/RecPaymentCreate.vue
@@ -18,7 +18,7 @@
 
                 <show-errors :error_msgs="form_errors" ></show-errors>
 
-                <form action="" class="wperp-form" method="post">
+                <div class="wperp-form">
                     <div class="wperp-row">
                         <div class="wperp-col-sm-4">
                             <div class="wperp-form-group">
@@ -61,7 +61,7 @@
 
                         <check-fields v-if="basic_fields.trn_by.id === '3'" @updateCheckFields="setCheckFields"></check-fields>
                     </div>
-                </form>
+                </div>
 
             </div>
         </div>
@@ -385,6 +385,10 @@ export default {
         },
 
         SubmitForPayment(event) {
+            if (this.isWorking) {
+                return;
+            }
+
             this.validateForm();
 
             if (this.form_errors.length) {
@@ -394,6 +398,8 @@ export default {
                 });
                 return;
             }
+
+            this.isWorking = true;
 
             this.invoices.forEach((element, index) => {
                 element['line_total'] = this.negativeAmount[index] ? (-1 * parseFloat(this.totalAmounts[index])) : parseFloat(this.totalAmounts[index]);
@@ -449,6 +455,7 @@ export default {
                 }
             }).catch(error => {
                 this.$store.dispatch('spinner/setSpinner', false);
+                this.isWorking = false;
                 throw error;
             });
         },

--- a/modules/accounting/assets/src/admin/components/select/ComboButton.vue
+++ b/modules/accounting/assets/src/admin/components/select/ComboButton.vue
@@ -2,7 +2,7 @@
     <div class="wperp-select-container select-primary combo-btns" v-click-outside="outside">
         <div class="wperp-selected-option">
               <div class="left-part" @click="optionSelected(options[0])">
-                <button type="submit" class="btn-fake">{{ options[0].text }}</button>
+                <button type="button" class="btn-fake">{{ options[0].text }}</button>
             </div>
 
               <div class="right-part" @click="toggleButtons">
@@ -12,7 +12,7 @@
 
         <ul class="wperp-options" v-show="showMenu">
             <li :key="index" @click="optionSelected(option)" v-for="(option, index) in options.slice(1)">
-                <button type="submit" class="btn-fake">{{ option.text }}</button>
+                <button type="button" class="btn-fake">{{ option.text }}</button>
             </li>
         </ul>
     </div>
@@ -44,6 +44,14 @@ export default {
             this.showMenu = false;
 
             this.$store.dispatch('combo/setBtnID', option.id);
+
+            // Find the closest parent form and submit it
+            this.$nextTick(() => {
+                const form = this.$el.closest('form');
+                if (form) {
+                    form.requestSubmit();
+                }
+            });
         },
 
         toggleButtons() {

--- a/modules/accounting/includes/functions/rec-payments.php
+++ b/modules/accounting/includes/functions/rec-payments.php
@@ -520,7 +520,7 @@ function erp_acct_change_invoice_status( $invoice_no ) {
 
     $due = (float) erp_acct_get_invoice_due( $invoice_no );
 
-    if ( 0.00 === $due ) {
+    if ( $due <= 0.00 ) {
         $wpdb->update(
             $wpdb->prefix . 'erp_acct_invoices',
             [


### PR DESCRIPTION
<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
## Summary

Fixes a bug where making a full payment on an invoice created **two payment vouchers** instead of one, leaving the invoice stuck in "Partially Paid" status. After this fix, a single payment is recorded and the invoice correctly updates to "Paid".

## Technical Notes

- Changed `erp_acct_change_invoice_status()` to treat overpaid invoices (negative due) the same as fully paid, as a backend safety net.
- No new hooks or public API changes.

## Security Considerations

- Added a double-submit guard on the payment form to prevent duplicate financial transactions from concurrent requests.



#### Related issue(s):
closes [#495](https://github.com/wp-erp/erp-pro/issues/495)