### PR TITLE
Fix: email sync regex warning #1562

### DIFF
--- a/modules/crm/includes/AjaxHandler.php
+++ b/modules/crm/includes/AjaxHandler.php
@@ -1388,10 +1388,13 @@ class AjaxHandler {
 				$headers .= "Reply-To: {$reply_to_name} <$reply_to>" . "\r\n";
 
 				$contact_owner_id = $contact->get_contact_owner();
+
+				$server_http_host = preg_replace('/[^a-zA-Z0-9:\.]/', '', isset($_SERVER['HTTP_HOST']) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '');
 				$server_host = apply_filters(
 					'erp_crm_activity_server_host',
-					isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''
+					$server_http_host
 				);
+				
 				$message_id       = md5( uniqid( time() ) ) . ".{$user_id}.{$contact_owner_id}.r2@{$server_host}";
 
 				$custom_headers = array(

--- a/modules/crm/includes/GmailSync.php
+++ b/modules/crm/includes/GmailSync.php
@@ -273,10 +273,12 @@ class GmailSync {
     public function process_emails( $emails ) {
         do_action( 'erp_crm_new_inbound_emails', $emails );
 
-        $http_host = apply_filters(
-            'erp_crm_activity_server_host',
-            isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''
-        );
+        $server_http_host = preg_replace('/[^a-zA-Z0-9:\.]/', '', isset($_SERVER['HTTP_HOST']) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '');
+		$http_host = apply_filters(
+			'erp_crm_activity_server_host',
+			$server_http_host
+		);
+
         $email_regexp = '([a-z0-9]+[.][0-9]+[.][0-9]+[.][r][1|2])@' . $http_host;
 
         foreach ( $emails as $email ) {

--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -2687,11 +2687,11 @@ function erp_crm_save_email_activity( $email, $inbound_email_address ) {
         $headers = '';
         $headers .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
 
-        $server_host = apply_filters(
-            'erp_crm_activity_server_host',
-            isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''
-        );
-        
+        $server_http_host = preg_replace('/[^a-zA-Z0-9:\.]/', '', isset($_SERVER['HTTP_HOST']) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '');
+		$server_host = apply_filters(
+			'erp_crm_activity_server_host',
+			$server_http_host
+		);
         $message_id  = md5( uniqid( time() ) ) . '.' . $contact_id . '.' . $contact_owner_id . '.r2@' . $server_host;
 
         $custom_headers = [
@@ -2779,10 +2779,11 @@ function erp_crm_save_contact_owner_email_activity( $email, $inbound_email_addre
     $headers = '';
     $headers .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
 
-    $server_host = apply_filters(
-        'erp_crm_activity_server_host',
-        isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''
-    );
+    $server_http_host = preg_replace('/[^a-zA-Z0-9:\.]/', '', isset($_SERVER['HTTP_HOST']) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '');
+	$server_host = apply_filters(
+		'erp_crm_activity_server_host',
+		$server_http_host
+	);
     $message_id  = md5( uniqid( time() ) ) . '.' . $save_data['user_id'] . '.' . $save_data['created_by'] . '.r1@' . $server_host;
 
     $custom_headers = [
@@ -3705,10 +3706,12 @@ function erp_crm_check_new_inbound_emails() {
 
         do_action( 'erp_crm_new_inbound_emails', $emails );
 
-        $server_host = apply_filters(
-            'erp_crm_activity_server_host',
-            isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''
-        );
+        $server_http_host = preg_replace('/[^a-zA-Z0-9:\.]/', '', isset($_SERVER['HTTP_HOST']) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '');
+		$server_host = apply_filters(
+			'erp_crm_activity_server_host',
+			$server_http_host
+		);
+        
         $email_regexp = '([a-z0-9]+[.][0-9]+[.][0-9]+[.][r][1|2])@' . $server_host;
 
         $filtered_emails = [];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Email references will contain the message id and the hostname in the format `<messageid@hostname.com>`, when using `esc_url_raw` it adds a protocol scheme (http://) to the hostname which will make the regex fail with a warning of unknown modifier. 

Instead of using `esc_url_raw` I suggest using `preg_replace` to remove any characters other than alphanumerical ones in addition to `.` and `:` from the hostname.

#### Related issue(s):

Email reference check failure due to the usage of `esc_url_raw` in sanitizing server host name
#1562