### PR TITLE
Add tutorial modal to accounting dashboard

### DIFF
--- a/modules/accounting/assets/src/admin/components/dashboard/DashBoard.vue
+++ b/modules/accounting/assets/src/admin/components/dashboard/DashBoard.vue
@@ -6,7 +6,7 @@
             <div class="wperp-row wperp-between-xs">
                 <div class="wperp-col">
                     <h2 class="content-header__title">{{ __('Dashboard', 'erp') }}</h2>
-                    <a class="wperp-btn btn--primary" :href="tutorialUrl" id="btn-tutorial-start">
+                    <a class="wperp-btn btn--primary" href="#" @click.prevent="showTutorial = true" id="btn-tutorial-start">
                         <span class="dashicons dashicons-controls-play"></span>
                         {{ __(' Start Tutorial', 'erp') }}
                     </a>
@@ -14,6 +14,27 @@
             </div>
         </div>
         <!-- End .header-section -->
+
+        <!-- Tutorial Video Modal -->
+        <div class="erp-tutorial-modal" v-if="showTutorial">
+            <div class="erp-tutorial-modal-overlay" @click="showTutorial = false"></div>
+            <div class="erp-tutorial-modal-content">
+                <div class="erp-tutorial-modal-header">
+                    <h3>{{ __('Accounting Tutorial', 'erp') }}</h3>
+                    <a href="#" class="erp-tutorial-modal-close" @click.prevent="showTutorial = false">&times;</a>
+                </div>
+                <div class="erp-tutorial-modal-body">
+                    <iframe
+                        width="100%"
+                        height="450"
+                        :src="tutorialVideoUrl"
+                        frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen
+                    ></iframe>
+                </div>
+            </div>
+        </div>
 
         <div class="wperp-dashboard">
             <div class="wperp-row">
@@ -115,9 +136,10 @@ export default {
             title4        : __('Bills to pay', 'erp'),
             closable      : true,
             msg           : __('Accounting', 'erp'),
-            to_receive    : [],
-            to_pay        : [],
-            tutorialUrl   : erp_acct_var.erp_acct_tut_url
+            to_receive      : [],
+            to_pay          : [],
+            showTutorial    : false,
+            tutorialVideoUrl: erp_acct_var.erp_acct_tut_url
         };
     },
 
@@ -164,3 +186,60 @@ export default {
     }
 };
 </script>
+
+<style scoped>
+.erp-tutorial-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.erp-tutorial-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+}
+.erp-tutorial-modal-content {
+    position: relative;
+    background: #fff;
+    border-radius: 6px;
+    width: 90%;
+    max-width: 850px;
+    z-index: 10000;
+    overflow: hidden;
+}
+.erp-tutorial-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid #e5e5e5;
+}
+.erp-tutorial-modal-header h3 {
+    margin: 0;
+    font-size: 16px;
+}
+.erp-tutorial-modal-close {
+    font-size: 24px;
+    text-decoration: none;
+    color: #666;
+    line-height: 1;
+}
+.erp-tutorial-modal-close:hover {
+    color: #000;
+}
+.erp-tutorial-modal-body {
+    padding: 0;
+}
+.erp-tutorial-modal-body iframe {
+    display: block;
+}
+</style>

--- a/modules/accounting/includes/Classes/Assets.php
+++ b/modules/accounting/includes/Classes/Assets.php
@@ -60,7 +60,6 @@ class Assets {
         $site_url          = site_url();
         $logout_url        = esc_url( wp_logout_url() );
         $acct_url          = admin_url( 'admin.php' ) . '?page=erp-accounting#/';
-        $acct_tutorial_url = admin_url( 'admin.php' ) . '?page=erp-accounting&tutorial=true#/';
 
         foreach ( $scripts as $handle => $script ) {
             $deps      = isset( $script['deps'] ) ? $script['deps'] : false;
@@ -114,7 +113,7 @@ class Assets {
             'erp_assets'          => WPERP_ASSETS,
             'erp_acct_menus'      => $menus,
             'erp_acct_url'        => $acct_url,
-            'erp_acct_tut_url'    => $acct_tutorial_url,
+            'erp_acct_tut_url'    => 'https://www.youtube.com/embed/M_HNHC9lBis?list=PLcxzJmmBmXv59j48tvCmAW-fYhQg6Blxe',
             'admin_url'           => admin_url( 'admin.php' ),
             'decimal_separator'   => $erp_acct_dec_separator,
             'thousand_separator'  => $erp_acct_ths_separator,


### PR DESCRIPTION
## Description

The "Start Tutorial" button on the Accounting Dashboard was throwing a JavaScript error due to corrupted JSON data in the WordPress pointer tooltip system. The `rawurlencode`/`decodeURIComponent` round-trip in `AccountingTutorial.php` was stripping special characters from the pointer JSON, causing `JSON.parse` to fail.

This change replaces the broken step-by-step pointer tutorial with a YouTube video playlist that opens in an in-page modal iframe.

## Changes

### `modules/accounting/assets/src/admin/components/dashboard/DashBoard.vue`
- Replaced the tutorial button's `href` navigation with a `@click` handler that opens a modal
- Added a modal overlay component with an embedded YouTube iframe player
- The iframe source URL is loaded from `erp_acct_var.erp_acct_tut_url` (passed from PHP)
- Added scoped CSS styles for the modal (overlay, content area, header, close button)

### `modules/accounting/includes/Classes/Assets.php`
- Removed unused `$acct_tutorial_url` variable (old `?tutorial=true` URL)
- Updated `erp_acct_tut_url` value to the YouTube embed playlist URL:
  `https://www.youtube.com/embed/M_HNHC9lBis?list=PLcxzJmmBmXv59j48tvCmAW-fYhQg6Blxe`

## How it works

1. User clicks "Start Tutorial" on the Accounting Dashboard
2. A modal overlay appears with the YouTube playlist embedded in an iframe
3. The playlist shows all tutorial videos with navigation on the right side
4. User can close the modal by clicking the X button or the overlay background

## Testing

1. Go to **WP ERP > Accounting** dashboard
2. Click the **Start Tutorial** button
3. Verify the YouTube playlist modal opens without errors
4. Verify the playlist sidebar is visible on the right
5. Verify closing the modal works (X button and overlay click)

Close [510](https://github.com/wp-erp/erp-pro/issues/510)