### PR TITLE
Add user_url/description and fix personal updates

### DIFF
--- a/modules/hrm/includes/API/CompanyController.php
+++ b/modules/hrm/includes/API/CompanyController.php
@@ -96,6 +96,42 @@ class CompanyController extends REST_Controller {
             ],
             'schema' => [ $this, 'get_public_item_schema' ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/termination-types', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_termination_types' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return current_user_can( 'erp_view_list' );
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/termination-reasons', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_termination_reasons' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return current_user_can( 'erp_view_list' );
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/rehire-options', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_rehire_options' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return current_user_can( 'erp_view_list' );
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
     }
 
     /**
@@ -196,6 +232,57 @@ class CompanyController extends REST_Controller {
         $reasons  = erp_hr_get_pay_change_reasons();
         $response = rest_ensure_response( $reasons );
         $response = $this->format_collection_response( $response, $request, count( $reasons ) );
+
+        return $response;
+    }
+
+    /**
+     * Get termination types
+     *
+     * @since 1.3.2
+     *
+     * @param $request
+     *
+     * @return mixed|object|WP_REST_Response
+     */
+    public function get_termination_types( $request ) {
+        $types    = erp_hr_get_terminate_type();
+        $response = rest_ensure_response( $types );
+        $response = $this->format_collection_response( $response, $request, count( $types ) );
+
+        return $response;
+    }
+
+    /**
+     * Get termination reasons
+     *
+     * @since 1.3.2
+     *
+     * @param $request
+     *
+     * @return mixed|object|WP_REST_Response
+     */
+    public function get_termination_reasons( $request ) {
+        $reasons  = erp_hr_get_terminate_reason();
+        $response = rest_ensure_response( $reasons );
+        $response = $this->format_collection_response( $response, $request, count( $reasons ) );
+
+        return $response;
+    }
+
+    /**
+     * Get rehire options
+     *
+     * @since 1.3.2
+     *
+     * @param $request
+     *
+     * @return mixed|object|WP_REST_Response
+     */
+    public function get_rehire_options( $request ) {
+        $options  = erp_hr_get_terminate_rehire_options();
+        $response = rest_ensure_response( $options );
+        $response = $this->format_collection_response( $response, $request, count( $options ) );
 
         return $response;
     }

--- a/modules/hrm/includes/API/CompanyController.php
+++ b/modules/hrm/includes/API/CompanyController.php
@@ -132,6 +132,38 @@ class CompanyController extends REST_Controller {
             ],
             'schema' => [ $this, 'get_public_item_schema' ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/genders', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_genders' ],
+                'permission_callback' => '__return_true',
+            ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/marital-statuses', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_marital_statuses' ],
+                'permission_callback' => '__return_true',
+            ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/education-result-types', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_education_result_types' ],
+                'permission_callback' => '__return_true',
+            ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/performance-ratings', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_performance_ratings' ],
+                'permission_callback' => '__return_true',
+            ],
+        ] );
     }
 
     /**
@@ -285,5 +317,21 @@ class CompanyController extends REST_Controller {
         $response = $this->format_collection_response( $response, $request, count( $options ) );
 
         return $response;
+    }
+
+    public function get_genders() {
+        return rest_ensure_response( erp_hr_get_genders() );
+    }
+
+    public function get_marital_statuses() {
+        return rest_ensure_response( erp_hr_get_marital_statuses() );
+    }
+
+    public function get_education_result_types() {
+        return rest_ensure_response( erp_hr_get_education_result_type_options() );
+    }
+
+    public function get_performance_ratings() {
+        return rest_ensure_response( erp_performance_rating() );
     }
 }

--- a/modules/hrm/includes/API/CompanyController.php
+++ b/modules/hrm/includes/API/CompanyController.php
@@ -84,6 +84,18 @@ class CompanyController extends REST_Controller {
             ],
             'schema' => [ $this, 'get_public_item_schema' ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/pay-change-reasons', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_pay_change_reasons' ],
+                'args'                => $this->get_collection_params(),
+                'permission_callback' => function ( $request ) {
+                    return current_user_can( 'erp_view_list' );
+                },
+            ],
+            'schema' => [ $this, 'get_public_item_schema' ],
+        ] );
     }
 
     /**
@@ -167,6 +179,23 @@ class CompanyController extends REST_Controller {
         $sources  = erp_hr_get_employee_sources();
         $response = rest_ensure_response( $sources );
         $response = $this->format_collection_response( $response, $request, count( $sources ) );
+
+        return $response;
+    }
+
+    /**
+     * Get pay change reasons
+     *
+     * @since 1.3.2
+     *
+     * @param $request
+     *
+     * @return mixed|object|WP_REST_Response
+     */
+    public function get_pay_change_reasons( $request ) {
+        $reasons  = erp_hr_get_pay_change_reasons();
+        $response = rest_ensure_response( $reasons );
+        $response = $this->format_collection_response( $response, $request, count( $reasons ) );
 
         return $response;
     }

--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -1703,6 +1703,9 @@ class EmployeesController extends REST_Controller {
             'country'         => '',
             'state'           => '',
             'postal_code'     => '',
+            'father_name'     => '',
+            'mother_name'     => '',
+            'spouse_name'     => '',
         ];
 
         $data = $item->get_data([], true);
@@ -2001,6 +2004,18 @@ class EmployeesController extends REST_Controller {
 
         if ( isset( $request['photo_id'] ) ) {
             $prepared_item['personal']['photo_id'] = $request['photo_id'];
+        }
+
+        if ( isset( $request['father_name'] ) ) {
+            $prepared_item['personal']['father_name'] = $request['father_name'];
+        }
+
+        if ( isset( $request['mother_name'] ) ) {
+            $prepared_item['personal']['mother_name'] = $request['mother_name'];
+        }
+
+        if ( isset( $request['spouse_name'] ) ) {
+            $prepared_item['personal']['spouse_name'] = $request['spouse_name'];
         }
 
         return $prepared_item;

--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -984,13 +984,13 @@ class EmployeesController extends REST_Controller {
             return new WP_Error( 'rest_invalid_employee_id', __( 'Invalid Employee id.', 'erp' ), [ 'status' => 404 ] );
         }
 
-        if ( empty( $module ) || ( ! in_array( $module, [ 'employment', 'compensation', 'job' ] ) ) ) {
+        if ( empty( $module ) || ( ! in_array( $module, [ 'employee', 'employment', 'compensation', 'job' ] ) ) ) {
             return new WP_Error( 'rest_no_module_type', __( 'Invalid/No module type', 'erp' ), [ 'status' => 404 ] );
         }
 
         $history = new WP_Error();
 
-        if ( $request['module'] == 'employment' ) {
+        if ( $request['module'] == 'employee' || $request['module'] == 'employment' ) {
             $history = $employee->update_employment_status( $request->get_params() );
         }
 
@@ -1016,18 +1016,26 @@ class EmployeesController extends REST_Controller {
 
     /**
      * Format history response to match get_job_histories() output
-     * 
+     *
      * @param array $history Raw history from update method
-     * @param string $module Module type (employment, compensation, job)
+     * @param string $module Module type (employee, employment, compensation, job)
      * @return array Formatted history data
      */
     private function format_history_response( $history, $module ) {
-        if ( $module === 'employment' ) {
-            // Employment updates return both type and category
+        if ( $module === 'employee' ) {
+            // Employee status updates
+            $formatted = [
+                'id'       => $history['id'],
+                'status'   => $history['category'],
+                'comments' => $history['comments'],
+                'date'     => $history['date'],
+                'module'   => $history['module'],
+            ];
+        } elseif ( $module === 'employment' ) {
+            // Employment type updates
             $formatted = [
                 'id'       => $history['id'],
                 'type'     => $history['type'],
-                'status'   => $history['category'],
                 'comments' => $history['comments'],
                 'date'     => $history['date'],
                 'module'   => $history['module'],

--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -1700,7 +1700,8 @@ class EmployeesController extends REST_Controller {
                 $reporting_to = new Employee( $item->get_reporting_to() );
 
                 if ( $reporting_to->is_employee() ) {
-                    $data['reporting_to'] = $this->prepare_item_for_response( $reporting_to );
+                    $reporting_to_response = $this->prepare_item_for_response( $reporting_to );
+                    $data['reporting_to'] = $reporting_to_response->get_data();
                 }
             }
 

--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -1005,9 +1005,60 @@ class EmployeesController extends REST_Controller {
         if ( is_wp_error( $history ) ) {
             return $history;
         }
-        $response = rest_ensure_response( $history );
+
+        // Transform response to match the format returned by get_job_histories()
+        $formatted_history = $this->format_history_response( $history, $module );
+
+        $response = rest_ensure_response( $formatted_history );
 
         return $response;
+    }
+
+    /**
+     * Format history response to match get_job_histories() output
+     * 
+     * @param array $history Raw history from update method
+     * @param string $module Module type (employment, compensation, job)
+     * @return array Formatted history data
+     */
+    private function format_history_response( $history, $module ) {
+        if ( $module === 'employment' ) {
+            // Employment updates return both type and category
+            $formatted = [
+                'id'       => $history['id'],
+                'type'     => $history['type'],
+                'status'   => $history['category'],
+                'comments' => $history['comments'],
+                'date'     => $history['date'],
+                'module'   => $history['module'],
+            ];
+        } elseif ( $module === 'compensation' ) {
+            // Compensation uses the standard format
+            $formatted = [
+                'id'       => $history['id'],
+                'comment'  => $history['comment'],
+                'pay_type' => $history['pay_type'],
+                'reason'   => $history['reason'],
+                'pay_rate' => $history['pay_rate'],
+                'date'     => $history['date'],
+                'module'   => $history['module'],
+            ];
+        } elseif ( $module === 'job' ) {
+            // Job updates
+            $formatted = [
+                'id'           => $history['id'],
+                'date'         => $history['date'],
+                'designation'  => $history['designation'],
+                'department'   => $history['department'],
+                'reporting_to' => $history['reporting_to'],
+                'location'     => $history['location'],
+                'module'       => $history['module'],
+            ];
+        } else {
+            $formatted = $history;
+        }
+
+        return $formatted;
     }
 
     /**
@@ -1758,6 +1809,7 @@ class EmployeesController extends REST_Controller {
 
                 // Format for frontend consumption
                 $data['employment_history'] = isset( $histories['employee'] ) ? $histories['employee'] : [];
+                $data['employment_type_history'] = isset( $histories['employment'] ) ? $histories['employment'] : [];
                 $data['compensation_history'] = isset( $histories['compensation'] ) ? $histories['compensation'] : [];
                 $data['job_history'] = isset( $histories['job'] ) ? $histories['job'] : [];
             }

--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -1717,6 +1717,45 @@ class EmployeesController extends REST_Controller {
             if ( in_array( 'job_histories', $include_params ) || in_array( 'histories', $include_params ) ) {
                 $histories = $item->get_job_histories( 'all' );
 
+                // Convert IDs to names and add reporting_to_full_name for job histories
+                if ( isset( $histories['job'] ) ) {
+                    for ( $i = 0; $i < count( $histories['job'] ); $i ++ ) {
+                        // Convert designation ID to name
+                        if ( ! empty( $histories['job'][ $i ]['designation'] ) ) {
+                            $designation = Designation::find( $histories['job'][ $i ]['designation'] );
+                            if ( $designation ) {
+                                $histories['job'][ $i ]['designation'] = $designation->title;
+                            }
+                        }
+
+                        // Convert department ID to name
+                        if ( ! empty( $histories['job'][ $i ]['department'] ) ) {
+                            $department = Department::find( $histories['job'][ $i ]['department'] );
+                            if ( $department ) {
+                                $histories['job'][ $i ]['department'] = $department->title;
+                            }
+                        }
+
+                        // Convert location ID to name
+                        if ( ! empty( $histories['job'][ $i ]['location'] ) && $histories['job'][ $i ]['location'] !== '-1' ) {
+                            $location = CompanyLocations::find( $histories['job'][ $i ]['location'] );
+                            if ( $location ) {
+                                $histories['job'][ $i ]['location'] = $location->name;
+                            }
+                        } elseif ( $histories['job'][ $i ]['location'] === '-1' ) {
+                            $histories['job'][ $i ]['location'] = 'Main Location';
+                        }
+
+                        // Convert reporting_to ID to name
+                        $reports_to = new Employee( $histories['job'][ $i ]['reporting_to'] );
+                        if ( $reports_to->is_employee() ) {
+                            $histories['job'][ $i ]['reporting_to_full_name'] = $reports_to->display_name;
+                        } else {
+                            $histories['job'][ $i ]['reporting_to_full_name'] = '';
+                        }
+                    }
+                }
+
                 // Format for frontend consumption
                 $data['employment_history'] = isset( $histories['employee'] ) ? $histories['employee'] : [];
                 $data['compensation_history'] = isset( $histories['compensation'] ) ? $histories['compensation'] : [];

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -1363,13 +1363,11 @@ class Employee {
             ->get();
 
         // Fetch expiration_date from user meta for each education
-        if ( $educations && is_countable( $educations ) && count( $educations ) > 0 ) {
-            $educations_array = $educations->toArray();
-            foreach ( $educations_array as &$edu ) {
-                $meta_key = 'education_' . $this->user_id . '_' . $edu['id'];
-                $edu['expiration_date'] = get_user_meta( $this->user_id, $meta_key, true );
+        if ( $educations && ! $educations->isEmpty() ) {
+            foreach ( $educations as $edu ) {
+                $meta_key = 'education_' . $this->user_id . '_' . $edu->id;
+                $edu->expiration_date = get_user_meta( $this->user_id, $meta_key, true );
             }
-            return $educations_array;
         }
 
         return $educations;

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -1356,11 +1356,23 @@ class Employee {
      * @return array the qualifications
      */
     public function get_educations( $limit = 30, $offset = 0 ) {
-        return $this->erp_user
+        $educations = $this->erp_user
             ->educations()
             ->skip( $offset )
             ->take( $limit )
             ->get();
+
+        // Fetch expiration_date from user meta for each education
+        if ( $educations && is_countable( $educations ) && count( $educations ) > 0 ) {
+            $educations_array = $educations->toArray();
+            foreach ( $educations_array as &$edu ) {
+                $meta_key = 'education_' . $this->user_id . '_' . $edu['id'];
+                $edu['expiration_date'] = get_user_meta( $this->user_id, $meta_key, true );
+            }
+            return $educations_array;
+        }
+
+        return $educations;
     }
 
     /**
@@ -1385,6 +1397,7 @@ class Employee {
             'result'      => '',
             'notes'       => '',
             'interest'    => '',
+            'expiration_date' => '',
         ];
 
         $args = wp_parse_args( $data, $default );
@@ -1416,7 +1429,12 @@ class Employee {
         if ( ! $education ) {
             return $this->send_error( 'error-creating-education', __( 'Could not create education.', 'erp' ) );
         } else {
-            update_user_meta( $education['employee_id'], 'education_' . $education['employee_id'] . '_' . $education['id'], $data['expiration_date'] );
+            // Save expiration_date to user meta if provided
+            if ( ! empty( $args['expiration_date'] ) ) {
+                update_user_meta( $education['employee_id'], 'education_' . $education['employee_id'] . '_' . $education['id'], $args['expiration_date'] );
+            }
+            // Add expiration_date to returned education array
+            $education['expiration_date'] = ! empty( $args['expiration_date'] ) ? $args['expiration_date'] : '';
         }
 
         return $education;
@@ -1428,6 +1446,11 @@ class Employee {
      * @since 1.3.0
      */
     public function delete_education( $id ) {
+        // Delete the expiration_date user meta
+        $meta_key = 'education_' . $this->user_id . '_' . $id;
+        delete_user_meta( $this->user_id, $meta_key );
+        
+        // Delete the education record
         return $this->erp_user->educations()->find( $id )->delete();
     }
 

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -1795,13 +1795,25 @@ class Employee {
             }
         }
 
-        $history = $this->get_erp_user()->histories()->updateOrCreate( [ 'id' => $args['id'] ], [
-            'module'   => $args['module'],
-            'category' => $args['category'],
-            'type'     => $args['type'],
-            'comment'  => $args['comments'],
-            'date'     => $args['date'],
-        ] );
+        // Build history update data - only include fields that are being updated
+        // to avoid overwriting existing values with empty defaults
+        $history_update_data = [
+            'module'  => $args['module'],
+            'comment' => $args['comments'],
+            'date'    => $args['date'],
+        ];
+
+        // Only include category if it's provided (status update)
+        if ( ! empty( $args['category'] ) ) {
+            $history_update_data['category'] = $args['category'];
+        }
+
+        // Only include type if it's provided (type update)
+        if ( ! empty( $args['type'] ) ) {
+            $history_update_data['type'] = $args['type'];
+        }
+
+        $history = $this->get_erp_user()->histories()->updateOrCreate( [ 'id' => $args['id'] ], $history_update_data );
 
         if (
             ! empty( $args['type'] ) &&

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -209,6 +209,8 @@ class Employee {
                 }
                 $this->data['personal']['full_name'] = $this->get_full_name();
                 $this->data['personal']['photo_id'] = $this->get_photo_id();
+                $this->data['personal']['user_url'] = $this->get_user_url();
+                $this->data['personal']['description'] = $this->get_description();
             }
         }
     }
@@ -334,8 +336,6 @@ class Employee {
         }
 
         if ( ! empty( $data['work']['designation'] ) && ! array_key_exists( $data['work']['designation'], erp_hr_get_designations_fresh() ) ) {
-            error_log(print_r( [erp_hr_get_departments_fresh()], true ));
-
             return new WP_Error( 'invalid-designation', __( 'Please select a valid employee designation', 'erp' ) );
         }
 
@@ -588,9 +588,11 @@ class Employee {
             }
         }
 
-        //check if something removed
+        // Check if something removed (field explicitly sent as empty).
+        // Important: do not treat omitted fields as removals, otherwise partial updates
+        // (e.g. updating Basic Info) would wipe unrelated Personal Details.
         foreach ( $this->data['personal'] as $p_key => $p_val ) {
-            if ( empty( $posted[ $p_key ] ) ) {
+            if ( array_key_exists( $p_key, $posted ) && ( '' === $posted[ $p_key ] || null === $posted[ $p_key ] ) ) {
                 $this->changes['personal'][ $p_key ] = '';
             }
         }
@@ -803,8 +805,28 @@ class Employee {
      *
      * @return string
      */
+    /**
+     * Get the user website URL from wp_users table
+     *
+     * @return string
+     */
     public function get_user_url() {
-        return $this->get_details_url();
+        if ( $this->user_id ) {
+            $user = get_user_by( 'id', $this->user_id );
+            if ( $user && isset( $user->user_url ) ) {
+                return $user->user_url;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Get the employees description/biography from user_meta
+     *
+     * @return string
+     */
+    public function get_description() {
+        return get_user_meta( $this->user_id, 'description', true );
     }
 
     /**


### PR DESCRIPTION
Populate personal.user_url and personal.description in Employee responses, and add get_user_url()/get_description() helpers to fetch website and bio from WP user data. Change EmployeesController to use prepare_item_for_response(...)->get_data() for reporting_to so nested response data is returned. Tighten removal detection for personal fields: only treat a field as removed when it is explicitly present and empty (avoids wiping fields during partial updates). Remove a stray error_log call from designation validation.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):

Related PRO [PR](https://github.com/wp-erp/erp-pro/pull/343)
