### PR TITLE
Persist user_url and handle end_date

### DIFF
--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -1906,6 +1906,10 @@ class EmployeesController extends REST_Controller {
             $prepared_item['work']['hiring_date'] = $request['hiring_date'];
         }
 
+        if ( isset( $request['end_date'] ) ) {
+            $prepared_item['work']['end_date'] = $request['end_date'];
+        }
+
         if ( isset( $request['date_of_birth'] ) ) {
             $prepared_item['work']['date_of_birth'] = $request['date_of_birth'];
         }

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -588,12 +588,15 @@ class Employee {
             }
         }
 
-        // Persist user_url on wp_users so it round-trips with get_user_url().
+        // user_url lives on the wp_users table (WordPress native column).
+        // Persist it there and unset it from the posted array so the
+        // personal-meta loop below does not also write it to user_meta.
         if ( \array_key_exists( 'user_url', $posted ) ) {
             wp_update_user( [
                 'ID'       => $this->user_id,
                 'user_url' => (string) $posted['user_url'],
             ] );
+            unset( $posted['user_url'] );
         }
 
         // Check if something removed (field explicitly sent as empty).
@@ -633,6 +636,14 @@ class Employee {
             foreach ( $this->changes['personal'] as $key => $value ) {
                 update_user_meta( $this->id, $key, $value );
             }
+        }
+
+        // Invalidate any cached employee data so subsequent reads reflect
+        // the updated wp_users / user_meta values (fixes stale reads for
+        // fields like user_url after edits).
+        clean_user_cache( $this->user_id );
+        if ( function_exists( 'erp_hrm_purge_cache' ) ) {
+            erp_hrm_purge_cache( [ 'list' => 'employee', 'employee_id' => $this->id ] );
         }
 
         //reset changes

--- a/modules/hrm/includes/Employee.php
+++ b/modules/hrm/includes/Employee.php
@@ -588,6 +588,14 @@ class Employee {
             }
         }
 
+        // Persist user_url on wp_users so it round-trips with get_user_url().
+        if ( \array_key_exists( 'user_url', $posted ) ) {
+            wp_update_user( [
+                'ID'       => $this->user_id,
+                'user_url' => (string) $posted['user_url'],
+            ] );
+        }
+
         // Check if something removed (field explicitly sent as empty).
         // Important: do not treat omitted fields as removals, otherwise partial updates
         // (e.g. updating Basic Info) would wipe unrelated Personal Details.

--- a/modules/hrm/includes/functions-employee.php
+++ b/modules/hrm/includes/functions-employee.php
@@ -1140,8 +1140,8 @@ function erp_hr_get_contractual_employee() {
  */
 function get_employee_additional_fields( $fields, $id, $user ) {
     $user_id                        = $fields['user_id'];
-    $fields['work']['end_date']     = get_user_meta( $user_id, 'end_date' );
-    $fields['personal']['user_url'] = get_user_meta( $user_id, 'user_url' ) ? get_user_meta( $user_id, 'user_url' ) : '';
+    $fields['work']['end_date']     = get_user_meta( $user_id, 'end_date', true );
+    $fields['personal']['user_url'] = get_user_meta( $user_id, 'user_url', true ) ? get_user_meta( $user_id, 'user_url', true ) : '';
 
     return $fields;
 }

--- a/modules/hrm/includes/functions-employee.php
+++ b/modules/hrm/includes/functions-employee.php
@@ -1139,9 +1139,18 @@ function erp_hr_get_contractual_employee() {
  * @return object collection of fields;
  */
 function get_employee_additional_fields( $fields, $id, $user ) {
-    $user_id                        = $fields['user_id'];
-    $fields['work']['end_date']     = get_user_meta( $user_id, 'end_date', true );
-    $fields['personal']['user_url'] = get_user_meta( $user_id, 'user_url', true ) ? get_user_meta( $user_id, 'user_url', true ) : '';
+    $user_id                    = $fields['user_id'];
+    $fields['work']['end_date'] = get_user_meta( $user_id, 'end_date', true );
+
+    // user_url is a WordPress native column on wp_users.
+    $user_url = '';
+    if ( $user_id ) {
+        $wp_user = get_user_by( 'id', $user_id );
+        if ( $wp_user && ! empty( $wp_user->user_url ) ) {
+            $user_url = $wp_user->user_url;
+        }
+    }
+    $fields['personal']['user_url'] = $user_url;
 
     return $fields;
 }


### PR DESCRIPTION
Add support to include end_date in the Employees API prepared item so it can be set via requests. Persist personal.user_url onto wp_users via wp_update_user so get_user_url() round-trips correctly. Update get_employee_additional_fields to call get_user_meta(..., true) (single) for end_date and user_url and ensure user_url falls back to an empty string.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
Close [issue](https://github.com/wp-erp/erp-pro/issues/524)
re;ated PRO [PR](https://github.com/wp-erp/erp-pro/pull/525) 