### PR TITLE
Use data->types when initializing contact types

### DIFF
--- a/modules/crm/includes/Contact.php
+++ b/modules/crm/includes/Contact.php
@@ -25,7 +25,12 @@ class Contact extends \WeDevs\ERP\People {
         }
 
         parent::__construct( $contact );
-        $this->types = $type ? (array) $type : $this->types;
+
+        if ( $type ) {
+            $this->types = (array) $type;
+        } elseif ( ! empty( $this->data->types ) && is_array( $this->data->types ) ) {
+            $this->types = $this->data->types;
+        }
     }
 
     /**


### PR DESCRIPTION
Adjust Contact constructor to populate $this->types from $this->data->types when no $type is provided. Previously the ternary left existing $this->types untouched; now the code explicitly sets types from the persisted data if available and an array, ensuring previously saved contact types are correctly restored during initialization.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
https://github.com/wp-erp/erp-pro/issues/550
