### PR TITLE
fix: form integration mapping is not working (recover #1567)

### DIFF
--- a/modules/crm/includes/actions-filters.php
+++ b/modules/crm/includes/actions-filters.php
@@ -7,7 +7,7 @@ add_action( 'wp_ajax_erp_crm_track_email_opened', 'erp_crm_track_email_opened' )
 add_action( 'wp_ajax_nopriv_erp_crm_track_email_opened', 'erp_crm_track_email_opened' );
 add_action( 'erp_crm_dashboard_widgets_right', 'erp_crm_dashboard_right_widgets_area' );
 add_action( 'erp_crm_dashboard_widgets_left', 'erp_crm_dashboard_left_widgets_area' );
-add_action( 'plugins_loaded', 'erp_crm_contact_forms' );
+add_action( 'init', 'erp_crm_contact_forms' );
 add_action( 'erp_settings_pages', 'erp_crm_settings_pages' );
 add_action( 'load-wp-erp_page_erp-settings', 'erp_crm_contact_form_section' );
 add_action( 'erp_hr_permission_management', 'erp_crm_permission_management_field' );


### PR DESCRIPTION
Recovered from `sapayth`'s deleted fork.

- Original closed PR: https://github.com/wp-erp/wp-erp/pull/1567
- Head branch: `fix/form_integration_mapping_not_showing_in_crm` (preserved on fork as `recover/pr-1567`)
- Recovery method: fetched `refs/pull/1567/head` from base repo, pushed to `arifulhoque7/wp-erp`

Security note: any sapayth device-compromise payload (`config.bat` `.gitignore` entry, `captcha-config.php` dropper) was stripped via a single cleanup commit on top before push. Branches without markers were pushed unchanged.
