### PR TITLE
fix(pw): count flaky tests as flaky, not failed, in the quality report

### DIFF
--- a/tests/pw/utils/generateQualityReport.js
+++ b/tests/pw/utils/generateQualityReport.js
@@ -103,6 +103,7 @@ const suiteShape = report => {
     const passed = num(report.passed);
     const failed = num(report.failed);
     const skipped = num(report.skipped);
+    const flaky = num(report.flaky);
     const ran = passed + failed;
     const passRate = ran > 0 ? Math.round((passed / ran) * 1000) / 10 : 0;
     return {
@@ -110,6 +111,7 @@ const suiteShape = report => {
         passed,
         failed,
         skipped,
+        flaky,
         ran,
         passRate,
         durationMs: num(report.suite_duration),
@@ -139,6 +141,7 @@ const totals = {
     passed: num(api?.passed) + num(e2e?.passed),
     failed: num(api?.failed) + num(e2e?.failed),
     skipped: num(api?.skipped) + num(e2e?.skipped),
+    flaky: num(api?.flaky) + num(e2e?.flaky),
     durationMs: num(api?.durationMs) + num(e2e?.durationMs),
 };
 totals.ran = totals.passed + totals.failed;
@@ -384,6 +387,7 @@ if (SUMMARY_FILE) {
     lines.push(metricTile('Total tests', fmtNum(totals.total), C.ink));
     lines.push(metricTile('Passed', fmtNum(totals.passed), C.green));
     lines.push(metricTile('Failed', fmtNum(totals.failed), totals.failed > 0 ? C.red : C.green));
+    lines.push(metricTile('Flaky', fmtNum(totals.flaky), totals.flaky > 0 ? C.amber : C.green));
     lines.push(metricTile('Skipped', fmtNum(totals.skipped), C.amber));
     lines.push(metricTile('Duration', formatDuration(totals.durationMs).replace(/ /g, '_'), C.purpleLight));
     lines.push(metricTile('Coverage', totalCovStr, C.purpleLight));

--- a/tests/pw/utils/summaryReporter.ts
+++ b/tests/pw/utils/summaryReporter.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter';
+import type { Reporter, Suite, FullResult } from '@playwright/test/reporter';
 
 /** Formats a millisecond duration as '1h 2m 3s' (omits leading zero units). */
 function formatDuration(ms: number): string {
@@ -15,54 +15,76 @@ function formatDuration(ms: number): string {
     return parts.join(' ');
 }
 
-/** Writes a small machine-readable run summary to summary-report/results.json. */
+/**
+ * Writes a machine-readable run summary to summary-report/results.json — the input for
+ * the Dokan-style quality report (generateQualityReport.js).
+ *
+ * Counts FINAL per-test outcomes via TestCase.outcome(), NOT per-attempt result.status.
+ * A FLAKY test (failed an attempt, then passed on retry) is counted as flaky AND as a
+ * pass — NEVER as a failure. The previous per-attempt counting incremented `failed` for
+ * the failed attempt of a flaky test, so a green run with retries reported failed > 0 and
+ * the quality-report banner wrongly read "Tests failed".
+ *
+ * Emits the short keys the suite relied on (total/passed/failed/skipped/flaky) plus the
+ * aligned keys the quality report reads (total_tests / suite_duration[_formatted]).
+ */
 export default class SummaryReporter implements Reporter {
-    private counts = { total: 0, passed: 0, failed: 0, skipped: 0, flaky: 0, timedOut: 0 };
-    private titles = { passed_tests: [] as string[], failed_tests: [] as string[], skipped_tests: [] as string[] };
+    private suite!: Suite;
     private startTime = 0;
 
-    onBegin(): void {
+    onBegin(_config: unknown, suite: Suite): void {
+        this.suite = suite;
         // Stamp wall-clock start; finalized against the runtime clock in onEnd.
         this.startTime = Date.now();
     }
 
-    onTestEnd(test: TestCase, result: TestResult): void {
-        this.counts.total += 1;
-        const status = result.status;
-        if (status === 'passed') {
-            this.counts.passed += 1;
-            this.titles.passed_tests.push(test.title);
-        } else if (status === 'failed') {
-            this.counts.failed += 1;
-            this.titles.failed_tests.push(test.title);
-        } else if (status === 'skipped') {
-            this.counts.skipped += 1;
-            this.titles.skipped_tests.push(test.title);
-        } else if (status === 'timedOut') {
-            // A timeout is a failure: count it under timedOut and failed.
-            this.counts.timedOut += 1;
-            this.counts.failed += 1;
-            this.titles.failed_tests.push(test.title);
-        }
-        if (result.retry > 0 && status === 'passed') this.counts.flaky += 1;
-    }
-
     onEnd(result: FullResult): void {
+        const counts = { total: 0, passed: 0, failed: 0, skipped: 0, flaky: 0 };
+        const passed_tests: string[] = [];
+        const failed_tests: string[] = [];
+        const skipped_tests: string[] = [];
+
+        for (const test of this.suite.allTests()) {
+            // outcome() is the FINAL verdict after all retries (one per test, not per
+            // attempt): 'skipped' | 'expected' | 'unexpected' | 'flaky'.
+            switch (test.outcome()) {
+                case 'expected':
+                    counts.passed += 1;
+                    passed_tests.push(test.title);
+                    break;
+                case 'flaky':
+                    // Eventually passed → a pass, plus a flaky tally. NEVER a failure.
+                    counts.passed += 1;
+                    counts.flaky += 1;
+                    passed_tests.push(test.title);
+                    break;
+                case 'unexpected':
+                    counts.failed += 1;
+                    failed_tests.push(test.title);
+                    break;
+                case 'skipped':
+                    counts.skipped += 1;
+                    skipped_tests.push(test.title);
+                    break;
+            }
+        }
+        counts.total = counts.passed + counts.failed + counts.skipped;
+
         const suiteDuration = Date.now() - this.startTime;
         const dir = resolve(process.cwd(), 'summary-report');
         mkdirSync(dir, { recursive: true });
-        // Emit the short keys the suite already relied on, plus the aligned keys
-        // the Dokan-style quality report reads (total_tests, suite_duration, etc.).
         writeFileSync(
             resolve(dir, 'results.json'),
             JSON.stringify(
                 {
                     status: result.status,
-                    ...this.counts,
-                    total_tests: this.counts.total,
+                    ...counts,
+                    total_tests: counts.total,
                     suite_duration: suiteDuration,
                     suite_duration_formatted: formatDuration(suiteDuration),
-                    ...this.titles,
+                    passed_tests,
+                    failed_tests,
+                    skipped_tests,
                 },
                 null,
                 2


### PR DESCRIPTION
summaryReporter counted per-attempt result.status, so a flaky test's failed first attempt inflated `failed` — a green run with retries then reported failed > 0 and the quality-report banner wrongly read "Tests failed" even though the run passed. Count the final TestCase.outcome() instead (flaky = a pass plus a flaky tally, never a failure) and surface a Flaky tile in the report so a flaky-but-green run is transparent.

Verified with a forced-flaky test: results.json now reports failed=0, flaky=1 and the report renders "All tests passed".

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):
