### PR TITLE
Fix authenticated SQL injection via orderby in leave requests

### DIFF
--- a/modules/hrm/includes/functions-leave.php
+++ b/modules/hrm/includes/functions-leave.php
@@ -1364,22 +1364,25 @@ function erp_hr_get_leave_requests( $args = [], $cached = true ) {
         }
     } );
 
-    // fix orderby parameter
-    if ( $args['orderby'] == 'created_on' ) {
-        $args['orderby'] = 'request.created_at';
-    } elseif ( in_array( $args['orderby'], [ 'start_date', 'end_date', 'name', 'created_at' ] ) ) {
-        $args['orderby'] = 'request.' . $args['orderby'];
-    } elseif ( $args['orderby'] == 'name' ) {
-        $args['orderby'] = 'u.' . $args['orderby'];
-    }elseif ( $args['orderby'] == 'days' ) {
-        $args['orderby'] = 'request.days';
-    }elseif ( $args['orderby'] == 'policy' ) {
-        $args['orderby'] = 'policy.id';
-    }elseif ( $args['orderby'] == 'last_status' ) {
-        $args['orderby'] = 'request.last_status';
-    }elseif ( $args['orderby'] == 'available' ) {
-        $args['orderby'] = 'request.leave_entitlement_id';
-    }
+    // Map allowed orderby values to their safe column expressions. ORDER BY targets
+    // a column/expression (an identifier), not a string literal, so it cannot be
+    // safely escaped with $wpdb->prepare(). Any value outside this whitelist falls
+    // back to a known-safe default to prevent SQL injection via the orderby param.
+    $orderby_map = [
+        'created_on'  => 'request.created_at',
+        'created_at'  => 'request.created_at',
+        'start_date'  => 'request.start_date',
+        'end_date'    => 'request.end_date',
+        'name'        => 'u.display_name',
+        'days'        => 'request.days',
+        'policy'      => 'policy.id',
+        'last_status' => 'request.last_status',
+        'available'   => 'request.leave_entitlement_id',
+    ];
+
+    $args['orderby'] = isset( $orderby_map[ $args['orderby'] ] )
+        ? $orderby_map[ $args['orderby'] ]
+        : 'request.created_at';
 
     $last_changed = erp_cache_get_last_changed( 'hrm', 'leave_request' );
     $cache_key    = 'erp_hr_leave_requests_' . md5( serialize( $args ) ) . ": $last_changed";
@@ -1405,8 +1408,8 @@ function erp_hr_get_leave_requests( $args = [], $cached = true ) {
     $where .= " AND entl.trn_type = 'leave_policies'";
 
     $groupby = '';
-    $orderby = $wpdb->prepare( " ORDER BY %s %s", $args['orderby'], $args['order'] );
-    $orderby = esc_sql( str_replace( '\'', '', $orderby ) );
+    $order   = strtoupper( $args['order'] ) === 'ASC' ? 'ASC' : 'DESC';
+    $orderby = " ORDER BY {$args['orderby']} {$order}";
     $offset = absint( $args['offset'] );
     $number = absint( $args['number'] );
     $limit  = $args['number'] == '-1' ? '' : $wpdb->prepare(" LIMIT %d, %d", $offset, $number);


### PR DESCRIPTION
## Summary
fixes wp-erp/erp-pro#730

Fixes an authenticated (HR Manager+) SQL injection in `erp_hr_get_leave_requests()` reported in wp-erp/erp-pro#730 (CWE-89).

The `orderby` parameter was built as:

```php
$orderby = $wpdb->prepare( " ORDER BY %s %s", $args['orderby'], $args['order'] );
$orderby = esc_sql( str_replace( '\'', '', $orderby ) );
```

`$wpdb->prepare( "%s", ... )` wraps the value in single quotes, then `str_replace` **strips those quotes back off**, leaving raw user input in the `ORDER BY` clause. `esc_sql()` does not escape parentheses or SQL keywords, so a payload like `(SELECT SLEEP(3))` executes:

```
ORDER BY (SELECT SLEEP(3)) DESC
```

Exploitable by any user with the `erp_list_employee` capability (HR Manager and above).

## Fix

`ORDER BY` targets a column/expression identifier, not a string literal — it cannot be safely escaped with `prepare()`. Replaced the `prepare` + `str_replace` + `esc_sql` pattern with:

- A strict **whitelist map** of allowed `orderby` values to safe column expressions, with a known-safe fallback (`request.created_at`) for anything else.
- Order direction restricted to `ASC` / `DESC` only.

No user-supplied value reaches the query string anymore. Also corrects the previously dead/incorrect `name` mapping (now maps to `u.display_name`, matching the `SELECT`).

## Testing

- `php -l` passes.
- PoC `orderby=(SELECT SLEEP(N))` no longer injects — value is not in whitelist, falls back to `request.created_at`.

Refs wp-erp/erp-pro#730

🤖 Generated with [Claude Code](https://claude.com/claude-code)