### PR TITLE
Fix stored XSS in CRM schedule message and leave attachment exposure

### DIFF
--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -643,7 +643,9 @@ function erp_crm_customer_prepare_schedule_postdata( $postdata ) {
         'id'         => ( isset( $postdata['id'] ) && ! empty( $postdata['id'] ) ) ? $postdata['id'] : '',
         'user_id'    => $postdata['user_id'],
         'created_by' => $postdata['created_by'],
-        'message'    => $postdata['message'],
+        // Sanitize the message before persisting to prevent stored XSS. wp_kses_post()
+        // keeps safe formatting markup while stripping <script>, event handlers, etc.
+        'message'    => isset( $postdata['message'] ) ? wp_kses_post( $postdata['message'] ) : '',
         'type'       => 'log_activity',
         'log_type'   => ( isset( $postdata['schedule_type'] ) && ! empty( $postdata['schedule_type'] ) ) ? $postdata['schedule_type'] : '',
         'start_date' => erp_current_datetime()->modify( $postdata['start_date'] . $start_time )->format( 'Y-m-d H:i:s' ),
@@ -953,7 +955,9 @@ function erp_crm_customer_get_single_activity_feed( $feed_id ) {
         }
 
         $data['contact']['types'] = wp_list_pluck( $data['contact']['types'], 'name' );
-        $data['message']          = stripslashes( $data['message'] );
+        // Sanitize on read so legacy rows stored before the save-side fix cannot
+        // execute script in the schedule-details popup (rendered via raw {{{ }}}).
+        $data['message']          = wp_kses_post( stripslashes( $data['message'] ) );
 
         if ( isset( $data['extra']['attachments'] ) ) {
             $data['extra']['attachments'] = erp_crm_process_attachment_data( $data['extra']['attachments'] );

--- a/modules/hrm/includes/API/LeaveRequestsController.php
+++ b/modules/hrm/includes/API/LeaveRequestsController.php
@@ -808,8 +808,17 @@ class LeaveRequestsController extends REST_Controller {
     public function prepare_item_for_response( $item, $request, $additional_fields = [] ) {
         $employee = new Employee( $item->user_id );
 
-        $attachments      = [];
-        $leave_attachment = get_user_meta( $item->user_id, 'leave_document_' . $item->id );
+        $attachments = [];
+
+        // Leave documents may contain sensitive HR material. Only expose attachment
+        // URLs to the leave owner or to users who can manage leave, rather than to
+        // anyone holding the broad list/view capability.
+        $can_view_attachments = ( get_current_user_id() === (int) $item->user_id )
+            || current_user_can( 'erp_leave_manage' );
+
+        $leave_attachment = $can_view_attachments
+            ? get_user_meta( $item->user_id, 'leave_document_' . $item->id )
+            : [];
 
         if ( ! empty( $leave_attachment ) ) {
             foreach ( $leave_attachment as $attachment_id ) {


### PR DESCRIPTION
Addresses two findings from the automated WordPress.org plugin security review (erp-pro issue #739).

1. Stored XSS — CRM schedule message (high): The schedule `message` was persisted verbatim and rendered as raw HTML via the Underscore template `{{{ data.schedule.message }}}`, which is inserted into the DOM with `.html()`. A CRM user able to create/edit a schedule could store JavaScript that executes in a privileged viewer's browser.
   - Sanitize the message with wp_kses_post() before persistence in erp_crm_customer_prepare_schedule_postdata() — keeps safe formatting markup while stripping <script>, event handlers, etc.
   - Sanitize on read in erp_crm_customer_get_single_activity_feed() so legacy rows stored before this fix can no longer execute script.

2. Leave attachment exposure (medium): prepare_item_for_response() emitted leave-document attachment URLs to any caller passing the broad list/view gate. Restrict attachment URLs to the leave owner or users with erp_leave_manage, preserving HR access while removing exposure to plain list-viewers.

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s): 
fixes https://github.com/wp-erp/erp-pro/issues/739
