### PR TITLE
enhance: prevent CRM agent from viewing others' contacts

### DIFF
--- a/includes/API/ActivitiesController.php
+++ b/includes/API/ActivitiesController.php
@@ -23,6 +23,13 @@ class ActivitiesController extends REST_Controller {
      */
     protected $rest_base = 'crm/activities';
 
+    /**
+     * Activity types map.
+     *
+     * @var array
+     */
+    protected $activity_types = [];
+
     public function __construct() {
         $this->activity_types = [
             'note'     => 'new_note',

--- a/includes/API/ApiRegistrar.php
+++ b/includes/API/ApiRegistrar.php
@@ -29,12 +29,12 @@ class ApiRegistrar {
             '\WeDevs\ERP\API\UtilityController',
         ];
 
-        if ( erp_is_module_active( 'CRM' ) ) {
+        if ( erp_is_module_active( 'crm' ) ) {
             $controllers = array_merge( $controllers, [
-                '\WeDevs\ERP\API\Contacts_Controller',
-                '\WeDevs\ERP\API\Contacts_Groups_Controller',
-                '\WeDevs\ERP\API\Activities_Controller',
-                '\WeDevs\ERP\API\Schedules_Controller',
+                '\WeDevs\ERP\API\ContactsController',
+                '\WeDevs\ERP\API\ContactsGroupsController',
+                '\WeDevs\ERP\API\ActivitiesController',
+                '\WeDevs\ERP\API\SchedulesController',
             ] );
         }
 

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -959,7 +959,7 @@ class SetupWizard {
                 <div class="erp-setup-next-steps-first">
                     <h2><?php esc_html_e( 'Next Steps &rarr;', 'erp' ); ?></h2>
                     <?php
-                        $is_hrm_activated = erp_is_module_active( 'HRM' );
+                        $is_hrm_activated = erp_is_module_active( 'hrm' );
 
                         if ( $is_hrm_activated ) { ?>
                             <a class="button button-primary button-large btn-add-employees"

--- a/includes/Admin/views/tools.php
+++ b/includes/Admin/views/tools.php
@@ -3,9 +3,9 @@
     <?php
     $current_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'general';
 
-    $is_crm_activated = erp_is_module_active( 'CRM' );
-    $is_hrm_activated = erp_is_module_active( 'HRM' );
-    $is_acc_activated = erp_is_module_active( 'Accounting' );
+    $is_crm_activated = erp_is_module_active( 'crm' );
+    $is_hrm_activated = erp_is_module_active( 'hrm' );
+    $is_acc_activated = erp_is_module_active( 'accounting' );
 
     $erp_import_export_fields = erp_get_import_export_fields();
     $keys                     = array_keys( $erp_import_export_fields );

--- a/includes/Framework/views/status-report.php
+++ b/includes/Framework/views/status-report.php
@@ -200,7 +200,7 @@ $security         = $system_status->get_security_info();
 			<td><?php echo esc_html( erp_get_option( 'erp_ac_currency_position', false, 'left' ) ); ?></td>
 		</tr>
 
-		<?php if ( erp_is_module_active( 'Accounting' ) ) { ?>
+		<?php if ( erp_is_module_active( 'accounting' ) ) { ?>
 		<tr>
 			<td data-export-label="Thousand Separator"><?php esc_html_e( 'Thousand Separator', 'erp' ); ?>:</td>
 			<td class="help"></td>

--- a/includes/functions-cache-helper.php
+++ b/includes/functions-cache-helper.php
@@ -138,7 +138,7 @@ function erp_crm_purge_cache( $args = [] ) {
             wp_cache_delete( 'erp-crm-customer-status-counts-' . $args['type'], $group );
 
             // @todo: This process needs to be improved. Now It's left like this on emergency basis.
-            if ( erp_is_module_active( 'CRM' ) ) {
+            if ( erp_is_module_active( 'crm' ) ) {
                 if ( ! erp_crm_is_current_user_manager() && erp_crm_is_current_user_crm_agent() ) {
                     wp_cache_delete( 'erp-crm-customer-status-counts-' . $args['type'] . '-agent-id-' . get_current_user_id(), $group );
                 } elseif ( erp_crm_is_current_user_manager() ) {

--- a/includes/functions-people.php
+++ b/includes/functions-people.php
@@ -45,7 +45,7 @@ function erp_get_peoples( $args = [] ) {
     $args                 = wp_parse_args( $args, $defaults );
     $args['crm_agent_id'] = false;
 
-    if ( erp_is_module_active( 'CRM' ) ) {
+    if ( erp_is_module_active( 'crm' ) ) {
         $args['crm_agent_id'] = ( ! erp_crm_is_current_user_manager() && erp_crm_is_current_user_crm_agent() ) ? get_current_user_id() : false;
     }
 
@@ -144,7 +144,7 @@ function erp_get_peoples( $args = [] ) {
             $sql['where'][] = $wpdb->prepare( "AND people.contact_owner = %d", $contact_owner );
         }
 
-        if ( erp_is_module_active( 'CRM' ) ) {
+        if ( erp_is_module_active( 'crm' ) ) {
             if ( ! erp_crm_is_current_user_manager() && erp_crm_is_current_user_crm_agent() && apply_filters( 'erp_crm_limit_contacts_to_owner', true ) ) {
                 $current_user_id = get_current_user_id();
                 $sql['where'][]  = $wpdb->prepare( "AND people.contact_owner = %d", $current_user_id );


### PR DESCRIPTION
erp_is_module_active() is case-sensitive: it checks isset( $modules[ $module_key ] ) against the erp_modules option whose keys are lowercase ('crm', 'hrm', 'accounting'). Callers passing 'CRM'/'HRM'/'Accounting' always got false, so the CRM agent contact-scoping branch in erp_get_peoples() never ran and agents could see every contact instead of only their own.

Lowercase all module keys passed to erp_is_module_active() across ApiRegistrar, SetupWizard, tools view, status report, cache helper, and functions-people so the agent ownership WHERE clause applies.

In ApiRegistrar the CRM controller list was previously dead (guarded by the always-false 'CRM' check) and still referenced the old underscore class names (Contacts_Controller, ...). Enabling the check would fatal on those missing classes, so also correct them to the current names (ContactsController, ContactsGroupsController, ActivitiesController, SchedulesController) so the CRM REST routes register instead of crashing rest_api_init.

Recovers PR #1577 (originally #1568).

<!-- Thanks for contributing to WP ERP! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:


#### Related issue(s):

fixes https://github.com/wp-erp/erp-pro/issues/300