### PR TITLE
fix: add capability check to company location creation (CVE-2026-15349)

### DIFF
--- a/includes/Admin/Ajax.php
+++ b/includes/Admin/Ajax.php
@@ -514,6 +514,11 @@ class Ajax {
      * @return void
      */
     public function location_create() {
+        // check permission for creating location
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->send_error( erp_get_message( ['type' => 'error_permission'] ) );
+        }
+
         if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'erp-company-location' ) ) {
             return;
         }


### PR DESCRIPTION
## Summary

Fixes a Missing Authorization vulnerability (CWE-862, CVE-2026-15349) in the `wp_ajax_erp-company-location` AJAX handler.

`location_create()` in `includes/Admin/Ajax.php` verified the nonce but performed **no capability check**. Since the `erp-company-location` nonce is rendered on `wp-admin/profile.php` (accessible to any logged-in user), an authenticated attacker with **subscriber-level access or above** could create arbitrary company locations in the ERP database.

## Fix

Added a `manage_options` capability check at the top of `location_create()`, matching the check already present in the sibling `location_remove()` handler.

```php
public function location_create() {
    // check permission for creating location
    if ( ! current_user_can( 'manage_options' ) ) {
        $this->send_error( erp_get_message( ['type' => 'error_permission'] ) );
    }
    ...
}
```

## Details

- **CVE:** CVE-2026-15349
- **CVSS:** 4.3 (Medium) — `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N`
- **Affected:** all versions up to and including 1.17.6
- **Researcher:** PRISM (via Wordfence)

## Related Issue

wp-erp/erp-pro#811

## Verification

- `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)