### PR TITLE
fix: unauthenticated arbitrary file upload via CRM Email Connect attachments

### DIFF
--- a/modules/crm/includes/GmailSync.php
+++ b/modules/crm/includes/GmailSync.php
@@ -217,17 +217,40 @@ class GmailSync {
 
         do_action( 'erp_crm_after_create_save_attachment_directory', $deal_id );
 
+        $real_dir = realpath( $dir );
+
+        if ( false === $real_dir ) {
+            return [];
+        }
+
+        $real_dir = trailingslashit( wp_normalize_path( $real_dir ) );
+
         foreach ( $attachments as $key => $item ) {
-            $name = $item['name'];
-            $file = wp_check_filetype( $item['name'] );
+            $name = $this->sanitize_attachment_filename( isset( $item['name'] ) ? $item['name'] : '' );
+
+            if ( empty( $name ) ) {
+                unset( $attachments[$key] );
+                continue;
+            }
+
+            $file = wp_check_filetype( $name );
 
             if ( file_exists( $dir . $name ) ) {
                 $name = uniqid() . '.' . $file['ext'];
             }
 
-            $saved = $wp_filesystem->put_contents( $dir . $name, $item['data'] );
+            // Make sure the resolved destination stays inside the CRM attachment directory.
+            $destination = wp_normalize_path( $dir . $name );
+
+            if ( 0 !== strpos( $destination, $real_dir ) ) {
+                unset( $attachments[$key] );
+                continue;
+            }
+
+            $saved = $wp_filesystem->put_contents( $destination, $item['data'] );
 
             if ( $saved ) {
+                $attachments[$key]['name'] = $name;
                 $attachments[$key]['slug'] = $name;
                 $attachments[$key]['path'] = $dir . $name;
                 //remove image data
@@ -240,6 +263,64 @@ class GmailSync {
         }
 
         return $attachments;
+    }
+
+    /**
+     * Sanitize an inbound email attachment file name.
+     *
+     * Strips any directory component, rejects control characters and encoded
+     * separators, and only allows extensions that WordPress considers safe.
+     * Server executable extensions are always rejected.
+     *
+     * @since 1.17.8
+     *
+     * @param string $filename
+     *
+     * @return string Empty string when the file name is not safe to store.
+     */
+    protected function sanitize_attachment_filename( $filename ) {
+        if ( ! is_string( $filename ) || '' === $filename ) {
+            return '';
+        }
+
+        // Decode so that encoded separators (%2f, %5c, ..) cannot slip through.
+        $filename = rawurldecode( $filename );
+
+        // Reject control characters and null bytes.
+        if ( preg_match( '/[\x00-\x1F\x7F]/', $filename ) ) {
+            return '';
+        }
+
+        // Drop any directory component from both separator styles.
+        $filename = str_replace( '\\', '/', $filename );
+        $filename = basename( $filename );
+        $filename = sanitize_file_name( $filename );
+
+        if ( '' === $filename || '.' === $filename || '..' === $filename ) {
+            return '';
+        }
+
+        if ( false !== strpos( $filename, '/' ) || false !== strpos( $filename, '\\' ) ) {
+            return '';
+        }
+
+        $file = wp_check_filetype( $filename, get_allowed_mime_types() );
+
+        if ( empty( $file['ext'] ) || empty( $file['type'] ) ) {
+            return '';
+        }
+
+        $blocked = apply_filters( 'erp_crm_blocked_attachment_extensions', [
+            'php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phps', 'pht', 'phtml', 'phar',
+            'shtml', 'cgi', 'pl', 'py', 'rb', 'sh', 'bash', 'exe', 'com', 'bat', 'cmd',
+            'jsp', 'asp', 'aspx', 'htaccess', 'htpasswd',
+        ] );
+
+        if ( in_array( strtolower( $file['ext'] ), $blocked, true ) ) {
+            return '';
+        }
+
+        return $filename;
     }
 
     public function format_header( $headers, $item ) {


### PR DESCRIPTION
Fixes wp-erp/erp-pro#869

## Problem

`GmailSync::save_attachments()` wrote inbound email attachments to `wp-content/uploads/crm-attachments/` using the filename supplied in the MIME part, without any validation. An unauthenticated attacker could email the site's configured inbound mailbox with a forged `References` header matching the plugin's expected pattern and an attachment named `../helper.php`, causing the cron IMAP sync to write attacker-controlled PHP into `wp-content/uploads/`, outside the `.htaccess`-protected attachment directory. On hosts where PHP executes in uploads this is remote code execution.

Both the Gmail API and IMAP inbound paths funnel into `save_attachments()`, so the fix is applied there.

## Changes

- New `sanitize_attachment_filename()` helper that:
  - rawurldecodes the filename so encoded separators (`%2f`, `%5c`) cannot slip through
  - rejects control characters and null bytes
  - strips any directory component (both `/` and `\`) via `basename()` + `sanitize_file_name()`
  - requires a valid extension/mime via `wp_check_filetype()` against `get_allowed_mime_types()`
  - blocks server-executable extensions (`php`, `phtml`, `phar`, `cgi`, `asp`, …), filterable via `erp_crm_blocked_attachment_extensions`
- `save_attachments()` skips attachments whose filename fails validation, and verifies the resolved destination path still lives inside the CRM attachment directory before writing.

## Testing

- `php -l` clean.
- Attachment named `../helper.php` is now rejected; nothing is written outside `crm-attachments/`.
- Ordinary attachments (pdf, png, docx) still save and remain reachable through `erp_crm_process_attachment_data()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)