### PR TITLE
Scope single-employee REST endpoint to object-level capability

### DIFF
--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -72,11 +72,7 @@ class EmployeesController extends REST_Controller {
                     'context' => $this->get_context_param( [ 'default' => 'view' ] ),
                 ],
                 'permission_callback' => function ( $request ) {
-                    $user_id = (int) $request['user_id'];
-                    $current_user_id = get_current_user_id();
-
-                    // Allow users to view their own profile or if they have erp_list_employee capability
-                    return ( $user_id === $current_user_id ) || current_user_can( 'erp_list_employee' );
+                    return current_user_can( 'erp_view_employee', (int) $request['user_id'] );
                 },
             ],
             [


### PR DESCRIPTION
The `GET /hrm/employees/{user_id}` permission check used `erp_list_employee` — a blanket capability held by every employee — so it returned the same result regardless of which id was requested. This switches it to `erp_view_employee`, the object-scoped capability (self or HR manager), matching how the sub-resource routes on the same controller already gate access.

```php
'permission_callback' => function ( $request ) {
    return current_user_can( 'erp_view_employee', (int) $request['user_id'] );
},
```

Note: `erp_view_employee` maps to self + HR manager. A plain reporting manager who isn't an HR manager will no longer read a report's profile through this route; if that access is intended, a `reporting_to` branch can be added to the `erp_view_employee` case in `erp_hr_map_meta_caps()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)