### PR TITLE
fix: prevent privilege escalation via CRM "Make WP User"

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2651,6 +2651,7 @@ function erp_array_flatten( $array ) {
  *
  * @since 1.3.1 function has been from crm
  * @since 1.2.4
+ * @since 1.17.9 Roles granting capabilities the current user does not have are removed
  *
  * @return array
  */
@@ -2664,9 +2665,85 @@ function erp_get_editable_roles() {
 		unset( $wp_roles['administrator'] );
 	}
 
+	// Prevent privilege escalation: a user must never be able to assign a role
+	// that holds capabilities the user does not have themselves.
+	foreach ( $wp_roles as $role_key => $role ) {
+		if ( ! erp_can_current_user_assign_role( $role_key, $role ) ) {
+			unset( $wp_roles[ $role_key ] );
+		}
+	}
+
 	$roles = apply_filters( 'erp_editable_roles', $wp_roles );
 
 	return $roles;
+}
+
+/**
+ * Check whether the current user is allowed to assign a given role.
+ *
+ * A role can only be assigned when the current user already holds every
+ * capability the role grants. This stops a low privileged user (e.g. a CRM
+ * agent with the subscriber role) from creating a WordPress user with a
+ * higher privileged role such as editor.
+ *
+ * @since 1.17.9
+ *
+ * @param string $role_key Role slug.
+ * @param array  $role     Optional. Role data as returned by `get_editable_roles()`.
+ *
+ * @return bool
+ */
+function erp_can_current_user_assign_role( $role_key, $role = [] ) {
+	if ( empty( $role_key ) ) {
+		return false;
+	}
+
+	if ( current_user_can( 'administrator' ) || current_user_can( 'promote_users' ) ) {
+		return true;
+	}
+
+	if ( empty( $role['capabilities'] ) ) {
+		$role_object = get_role( $role_key );
+
+		if ( ! $role_object ) {
+			return false;
+		}
+
+		$role = [ 'capabilities' => (array) $role_object->capabilities ];
+	}
+
+	$current_user = wp_get_current_user();
+	$user_caps    = ! empty( $current_user->allcaps ) ? array_filter( (array) $current_user->allcaps ) : [];
+
+	/**
+	 * Meta capabilities are resolved against a specific object, so they cannot be
+	 * compared between roles. They are ignored while diffing capabilities.
+	 */
+	$meta_caps = apply_filters( 'erp_role_comparison_ignored_caps', [
+		'edit_post',
+		'read_post',
+		'delete_post',
+		'edit_page',
+		'read_page',
+		'delete_page',
+		'edit_comment',
+		'edit_user',
+		'delete_user',
+		'remove_user',
+		'add_user_to_blog',
+	] );
+
+	foreach ( (array) $role['capabilities'] as $cap => $granted ) {
+		if ( ! $granted || in_array( $cap, $meta_caps, true ) ) {
+			continue;
+		}
+
+		if ( empty( $user_caps[ $cap ] ) ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**

--- a/modules/crm/includes/functions-customer.php
+++ b/modules/crm/includes/functions-customer.php
@@ -3922,6 +3922,7 @@ function erp_crm_sync_people_meta_data( $meta_id, $object_id, $meta_key, $_meta_
  *
  * @since 1.1.7
  * @since 1.1.18 Check if current user has permission to create wp user
+ * @since 1.17.9 Validate the requested role against the roles the current user may assign
  *
  * @param int   $customer_id
  * @param array $args        Optional parameter
@@ -3947,6 +3948,11 @@ function erp_crm_make_wp_user( $customer_id, $args = [] ) {
         return new WP_Error( 'no-email', __( 'No email found for creating wp user', 'erp' ) );
     }
 
+    // Never allow assigning a role that grants more capabilities than the current user holds.
+    if ( ! array_key_exists( $role, erp_get_editable_roles() ) || ! erp_can_current_user_assign_role( $role ) ) {
+        return new WP_Error( 'invalid-role', __( 'You are not allowed to create a user with the selected role', 'erp' ) );
+    }
+
     // attempt to create the user
     $userdata = [
         'user_login'   => $email,
@@ -3961,7 +3967,11 @@ function erp_crm_make_wp_user( $customer_id, $args = [] ) {
     $userdata['role']      = $role;
 
     $userdata = apply_filters( 'erp_crm_make_wpuser_args', $userdata );
-    $user_id  = wp_insert_user( $userdata );
+
+    // Re-assert the validated role in case a filter altered it.
+    $userdata['role'] = $role;
+
+    $user_id = wp_insert_user( $userdata );
 
     if ( is_wp_error( $user_id ) ) {
         return $user_id;
@@ -3977,8 +3987,22 @@ function erp_crm_make_wp_user( $customer_id, $args = [] ) {
     unset( $people['id'], $people['user_id'], $people['website'], $people['email'], $people['created'], $people['types'], $people['first_name'], $people['last_name'], $people['life_stage'], $people['contact_owner'] );
     $people_array = array_merge( $people, $meta_array );
 
+    global $wpdb;
+
+    // Meta keys that would alter the user's privileges must never be copied over.
+    $protected_meta_keys = [
+        $wpdb->get_blog_prefix() . 'capabilities',
+        $wpdb->get_blog_prefix() . 'user_level',
+        'wp_capabilities',
+        'wp_user_level',
+    ];
+
     if ( $people_array ) {
         foreach ( $people_array as $key => $value ) {
+            if ( in_array( $key, $protected_meta_keys, true ) || is_protected_meta( $key, 'user' ) ) {
+                continue;
+            }
+
             update_user_meta( $user_id, $key, $value );
         }
     }

--- a/tests/pw/.env.example
+++ b/tests/pw/.env.example
@@ -16,6 +16,8 @@ HR_MANAGER=hr_manager1
 CRM_MANAGER=crm_manager1
 ACC_MANAGER=acc_manager1
 EMPLOYEE=employee1
+# Subscriber + CRM agent: the low-privilege account the escalation specs use.
+CRM_AGENT=crm_agent1
 USER_PASSWORD=01erp01
 
 # WP ERP configuration

--- a/tests/pw/tests/api/security/crmRoleEscalation.api.spec.ts
+++ b/tests/pw/tests/api/security/crmRoleEscalation.api.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect, request } from '@utils/test';
+import { data } from '@utils/testData';
+import { dbUtils } from '@utils/dbUtils';
+import { tables } from '@utils/dbData';
+import { BASE_URL, toPath } from '@utils/helpers';
+import { CrmPage } from '../../e2e/crm/crmPage';
+
+/**
+ * Privilege-escalation regression specs for the CRM "Make WP User" flow.
+ *
+ * Reported as erp-pro#872: a user holding the ERP CRM agent role (normally paired
+ * with the WordPress subscriber role) could promote a contact they own into a
+ * WordPress user with any non-administrator role, Editor included. Because the
+ * agent chooses the contact's email address, they could then complete the password
+ * setup flow and log in with the escalated privileges.
+ *
+ * Root cause: erp_get_editable_roles() (includes/functions.php) built its allow-list
+ * from core's get_editable_roles() and stripped only `administrator`. Core does not
+ * capability-filter that list — it expects the caller to check promote_users /
+ * edit_users, which ERP never did. So `customer_role=editor` passed both the
+ * allow-list in AjaxHandler::make_wp_user() and erp_crm_make_wp_user() itself.
+ *
+ * These specs drive the real AJAX endpoint (`erp-crm-make-wp-user`) as the agent,
+ * because that is the attacker's actual entry point — asserting on the PHP helpers
+ * alone would not prove the HTTP path is closed. Each case checks BOTH that the
+ * request is refused AND that no WordPress user was actually created, since a
+ * "success: false" response with a user left behind is still an escalation.
+ */
+
+const ADMIN_AJAX = toPath('wp-admin/admin-ajax.php');
+
+/**
+ * The make-wp-user template is only printed on the contacts list screen
+ * (modules/crm/CRM.php: section=contact / sub-section=contacts), not on the CRM
+ * dashboard — so the nonce and the role dropdown only exist at this URL.
+ */
+const CONTACTS_URL = toPath('wp-admin/admin.php?page=erp-crm&section=contact&sub-section=contacts');
+
+/** Roles that grant capabilities a subscriber-level CRM agent does not hold. */
+const ESCALATED_ROLES = ['editor', 'author', 'contributor', 'administrator'] as const;
+
+let agentUserId: number;
+const seededEmails: string[] = [];
+
+/**
+ * Scrape the `erp-crm-make-wp-user` nonce out of the CRM admin page. The modal is a
+ * wp.template block rendered inline (modules/crm/views/js-templates/make-wp-user.php),
+ * so the nonce field ships with the page HTML even before the modal is opened.
+ *
+ * The generic `name="_wpnonce"` match is deliberately scoped to the make-wp-user
+ * template first: the CRM page carries several unrelated nonce fields, and grabbing
+ * the first one yields a token that fails verification for this action.
+ */
+function scrapeMakeWpUserNonce(html: string): string | undefined {
+    // Anchor on the template block, then take the nonce that immediately precedes
+    // this action's hidden input. wp_nonce_field() emits `id` before `name`, and the
+    // page carries several other nonce fields, so both the scope and the trailing
+    // action anchor matter.
+    const template = html.match(
+        /id="tmpl-erp-make-wp-user"[\s\S]*?name="_wpnonce"\s+value="([a-f0-9]+)"[\s\S]*?value="erp-crm-make-wp-user"/i,
+    );
+    return template?.[1];
+}
+
+/** Look up a WordPress user id by email, or undefined when no account exists. */
+async function findWpUserByEmail(email: string): Promise<number | undefined> {
+    const rows = await dbUtils.dbQuery<{ ID: number }>(`SELECT ID FROM ${tables.users} WHERE user_email = ? LIMIT 1`, [email]);
+    return rows[0]?.ID;
+}
+
+/** Read a user's serialized capabilities blob (raw, for substring role checks). */
+async function readCapabilities(userId: number): Promise<string> {
+    const prefix = process.env.DB_PREFIX ?? 'wp';
+    const rows = await dbUtils.dbQuery<{ meta_value: string }>(
+        `SELECT meta_value FROM ${tables.userMeta} WHERE user_id = ? AND meta_key = ? LIMIT 1`,
+        [userId, `${prefix}_capabilities`],
+    );
+    return rows[0]?.meta_value ?? '';
+}
+
+test.describe('CRM make-wp-user privilege escalation (erp-pro#872)', () => {
+    test.use({ storageState: data.auth.crmAgentFile });
+
+    test.beforeAll(async () => {
+        const rows = await dbUtils.dbQuery<{ ID: number }>(`SELECT ID FROM ${tables.users} WHERE user_login = ? LIMIT 1`, [
+            data.users.crmAgent.username,
+        ]);
+        agentUserId = Number(rows[0]?.ID ?? process.env.CRM_AGENT_ID ?? 0);
+        expect(agentUserId, 'CRM agent user was created by the auth setup').toBeGreaterThan(0);
+    });
+
+    test.afterAll(async () => {
+        // Remove any user/contact the specs created so reruns start clean.
+        for (const email of seededEmails) {
+            const userId = await findWpUserByEmail(email);
+            if (userId) {
+                await dbUtils.dbQuery(`DELETE FROM ${tables.userMeta} WHERE user_id = ?`, [userId]);
+                await dbUtils.dbQuery(`DELETE FROM ${tables.users} WHERE ID = ?`, [userId]);
+            }
+            await dbUtils.dbQuery(`DELETE FROM ${tables.peoples} WHERE email = ?`, [email]);
+        }
+        await dbUtils.close();
+    });
+
+    /**
+     * Seed a contact owned by the agent (ownership matters: erp_crm_edit_contact maps
+     * to do_not_allow for an agent unless contact_owner matches), then fire the
+     * make-wp-user AJAX request as that agent with the requested role.
+     */
+    async function attemptPromotion(
+        page: import('@playwright/test').Page,
+        role: string,
+    ): Promise<{ status: number; body: string; email: string }> {
+        const contact = data.crm.contact();
+        seededEmails.push(contact.email);
+
+        const contactId = await CrmPage.insertContactRow({
+            first_name: contact.first_name,
+            last_name: contact.last_name,
+            email: contact.email,
+            contact_owner: agentUserId,
+        });
+        expect(contactId, 'agent-owned contact was seeded').toBeTruthy();
+
+        await page.goto(CONTACTS_URL, { waitUntil: 'domcontentloaded' });
+        const nonce = scrapeMakeWpUserNonce(await page.content());
+        expect(nonce, 'make-wp-user nonce is present on the CRM page').toBeTruthy();
+
+        // page.request rides the agent's own cookies, so this is a genuine
+        // authenticated request from the low-privileged account.
+        const res = await page.request.post(ADMIN_AJAX, {
+            form: {
+                action: 'erp-crm-make-wp-user',
+                id: String(contactId),
+                type: 'contact',
+                customer_email: contact.email,
+                customer_role: role,
+                _wpnonce: nonce as string,
+            },
+        });
+
+        return { status: res.status(), body: await res.text(), email: contact.email };
+    }
+
+    for (const role of ESCALATED_ROLES) {
+        test(`agent cannot promote a contact to ${role}`, { tag: ['@lite', '@crm', '@security'] }, async ({ page }) => {
+            const { status, body, email } = await attemptPromotion(page, role);
+
+            // The handler answers 200 with {"success":false,...}; a hard 4xx or a
+            // bare -1/0 from admin-ajax is an equally valid refusal.
+            const denied =
+                status >= 400 ||
+                body.trim() === '0' ||
+                body.trim() === '-1' ||
+                /"success"\s*:\s*false/i.test(body) ||
+                /not allowed|do not have permission|sufficient permissions/i.test(body);
+            expect(denied, `promotion to ${role} was refused (body: ${body.slice(0, 200)})`).toBe(true);
+
+            // The refusal must be real: no account may exist for that email.
+            const userId = await findWpUserByEmail(email);
+            expect(userId, `no WordPress user was created for the ${role} attempt`).toBeUndefined();
+        });
+    }
+
+    test('agent can still promote a contact to subscriber', { tag: ['@lite', '@crm', '@security'] }, async ({ page }) => {
+        // The fix must not break the legitimate flow: subscriber grants nothing the
+        // agent does not already hold, so it stays allowed.
+        const { body, email } = await attemptPromotion(page, 'subscriber');
+        expect(/"success"\s*:\s*true/i.test(body), `subscriber promotion succeeded (body: ${body.slice(0, 200)})`).toBe(true);
+
+        const userId = await findWpUserByEmail(email);
+        expect(userId, 'subscriber account was created').toBeTruthy();
+
+        const caps = await readCapabilities(userId as number);
+        expect(caps).toContain('subscriber');
+        expect(caps).not.toContain('editor');
+    });
+
+    test('the role dropdown offers no role above the agent', { tag: ['@lite', '@crm', '@security'] }, async ({ page }) => {
+        // Server-rendered by erp_dropdown_roles() → erp_get_editable_roles(), so the
+        // markup itself proves the allow-list is capability-filtered rather than
+        // merely hidden client-side.
+        await page.goto(CONTACTS_URL, { waitUntil: 'domcontentloaded' });
+        const html = await page.content();
+
+        const select = html.match(/<select[^>]+name="customer_role"[\s\S]*?<\/select>/i)?.[0];
+        // erp_dropdown_roles() emits single-quoted attributes, but wp_kses may
+        // normalize them, so the option matcher below accepts either form.
+        expect(select, 'customer_role dropdown is rendered on the CRM page').toBeTruthy();
+
+        const offered = [...(select as string).matchAll(/value='([^']+)'|value="([^"]+)"/g)].map(m => m[1] ?? m[2]).filter(Boolean);
+        expect(offered.length, 'dropdown lists at least one assignable role').toBeGreaterThan(0);
+
+        for (const role of ESCALATED_ROLES) {
+            expect(offered, `dropdown does not offer ${role} to a CRM agent`).not.toContain(role);
+        }
+    });
+});
+
+test.describe('CRM make-wp-user requires authentication', () => {
+    test('anonymous make-wp-user request is rejected', { tag: ['@lite', '@crm', '@security'] }, async () => {
+        const ctx = await request.newContext({
+            baseURL: BASE_URL,
+            ...data.auth.noAuth,
+            ignoreHTTPSErrors: true,
+        });
+        const res = await ctx.post(ADMIN_AJAX, {
+            form: {
+                action: 'erp-crm-make-wp-user',
+                id: '1',
+                type: 'contact',
+                customer_email: 'anon_escalation@example.com',
+                customer_role: 'editor',
+            },
+        });
+        const body = await res.text();
+        const denied = res.status() >= 400 || body.trim() === '0' || body.trim() === '-1' || /"success"\s*:\s*false/i.test(body);
+        expect(denied, `anonymous request refused (body: ${body.slice(0, 200)})`).toBe(true);
+
+        const userId = await findWpUserByEmail('anon_escalation@example.com');
+        expect(userId, 'no account created for the anonymous attempt').toBeUndefined();
+        await ctx.dispose();
+        await dbUtils.close();
+    });
+});

--- a/tests/pw/tests/e2e/_auth.setup.ts
+++ b/tests/pw/tests/e2e/_auth.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup } from '@utils/test';
-import { login, getApiNonce, createEnvVar, ensureUser } from '@utils/helpers';
+import { login, getApiNonce, createEnvVar, ensureUser, ensureUserWithRoles } from '@utils/helpers';
 import { data } from '@utils/testData';
 
 /**
@@ -26,6 +26,17 @@ setup.describe('authentication & role users', () => {
             const id = ensureUser(u.username, u.email, u.role, password);
             if (id) createEnvVar(u.idKey, id);
         }
+
+        // The CRM agent is deliberately a *subscriber* with the CRM agent role layered
+        // on top — the exact low-privilege combination reported in erp-pro#872.
+        const agentId = ensureUserWithRoles(
+            data.users.crmAgent.username,
+            'crm_agent1@example.com',
+            'subscriber',
+            ['erp_crm_agent'],
+            password,
+        );
+        if (agentId) createEnvVar('CRM_AGENT_ID', agentId);
     });
 
     setup('authenticate HR manager', { tag: ['@lite'] }, async ({ page }) => {
@@ -52,5 +63,11 @@ setup.describe('authentication & role users', () => {
     });
     setup('authenticate Employee', { tag: ['@lite'] }, async ({ page }) => {
         await login(page, data.users.employee.username, data.users.employee.password, data.auth.employeeFile);
+    });
+    setup('authenticate CRM agent', { tag: ['@lite'] }, async ({ page }) => {
+        await login(page, data.users.crmAgent.username, data.users.crmAgent.password, data.auth.crmAgentFile);
+        // The agent reaches the CRM screens, so read its own nonce from erp-crm.
+        const nonce = await getApiNonce(page, 'wp-admin/admin.php?page=erp-crm');
+        if (nonce) createEnvVar('CRM_AGENT_NONCE', nonce);
     });
 });

--- a/tests/pw/tests/e2e/crm/crmPage.ts
+++ b/tests/pw/tests/e2e/crm/crmPage.ts
@@ -293,8 +293,12 @@ export class CrmPage {
      * uses) and return its id. Storage-fidelity tests use this for deterministic
      * round-trips of edge values (charset, case, phone formatting, truncation),
      * independent of the modal's async select2 timing.
+     *
+     * `contact_owner` defaults to the admin (see insertPerson). Pass it when the spec
+     * needs a non-admin to own the contact — erp_crm_edit_contact maps to do_not_allow
+     * for a CRM agent unless the owner matches, so permission specs depend on it.
      */
-    static async insertContactRow(args: { first_name: string; last_name?: string; email: string; phone?: string; life_stage?: string }): Promise<string | undefined> {
+    static async insertContactRow(args: { first_name: string; last_name?: string; email: string; phone?: string; life_stage?: string; contact_owner?: number }): Promise<string | undefined> {
         return CrmPage.insertPerson({ type: 'contact', ...args });
     }
 

--- a/tests/pw/utils/helpers.ts
+++ b/tests/pw/utils/helpers.ts
@@ -83,6 +83,27 @@ export function ensureUser(username: string, email: string, role: string, passwo
     }
 }
 
+/**
+ * Ensure a WP user exists with a primary role PLUS additional roles layered on top
+ * (`wp user add-role`, which appends instead of replacing). WP ERP roles are meant
+ * to be combined with a WordPress role — a CRM agent is normally also a subscriber
+ * — and that combination is exactly what the privilege-escalation specs exercise.
+ * Returns the user ID.
+ */
+export function ensureUserWithRoles(username: string, email: string, baseRole: string, extraRoles: string[], password: string): string {
+    const id = ensureUser(username, email, baseRole, password);
+    if (!id) return id;
+    for (const role of extraRoles) {
+        // add-role is idempotent: re-adding an existing role is a no-op.
+        try {
+            exeCommandWpcli(`user add-role ${id} ${role}`);
+        } catch {
+            // A role that is not registered yet (module disabled) must not abort setup.
+        }
+    }
+    return id;
+}
+
 /** Log a user into wp-admin and (optionally) persist the session as storageState. */
 export async function login(
     page: Page,

--- a/tests/pw/utils/testData.ts
+++ b/tests/pw/utils/testData.ts
@@ -17,6 +17,7 @@ export const data = {
         crmManagerFile: `${authDir}/crmManagerStorageState.json`,
         accManagerFile: `${authDir}/accManagerStorageState.json`,
         employeeFile: `${authDir}/employeeStorageState.json`,
+        crmAgentFile: `${authDir}/crmAgentStorageState.json`,
         noAuth: { storageState: { cookies: [], origins: [] } },
     },
 
@@ -26,6 +27,10 @@ export const data = {
         crmManager: { username: process.env.CRM_MANAGER ?? 'crm_manager1', password: process.env.USER_PASSWORD ?? '01erp01' },
         accManager: { username: process.env.ACC_MANAGER ?? 'acc_manager1', password: process.env.USER_PASSWORD ?? '01erp01' },
         employee: { username: process.env.EMPLOYEE ?? 'employee1', password: process.env.USER_PASSWORD ?? '01erp01' },
+        // Low-privileged CRM user: WordPress subscriber + ERP CRM agent. Used by the
+        // privilege-escalation specs (erp-pro#872), which assert that this account
+        // cannot mint WordPress users above its own capability level.
+        crmAgent: { username: process.env.CRM_AGENT ?? 'crm_agent1', password: process.env.USER_PASSWORD ?? '01erp01' },
     },
 
     // ── HRM factories ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the privilege escalation reported in wp-erp/erp-pro#872.

A user holding the ERP **CRM Agent** role (typically paired with the WordPress **Subscriber** role) could promote a contact they own into a WordPress user with any non-administrator role, including **Editor**. Because the agent controls the contact's email address, they could complete the "send password" setup flow and log in with the escalated privileges.

Reproduced and confirmed still present on `develop` (v1.17.8).

## Root cause

`erp_get_editable_roles()` (`includes/functions.php`) built its allow-list from core's `get_editable_roles()` and only removed `administrator`. WordPress core does not capability-filter that list — it relies on the caller checking `promote_users` / `edit_users`, which ERP never did. The CRM Agent role holds only `read`, `upload_files` and the `erp_crm_*` capabilities, yet `customer_role=editor` passed both the AJAX allow-list in `AjaxHandler::make_wp_user()` and `erp_crm_make_wp_user()`.

## Changes

### Fix

- **New `erp_can_current_user_assign_role()`** — a role may be assigned only when the current user already holds every capability that role grants. Administrators and users with `promote_users` short-circuit to allowed, so existing admin flows are untouched.
  Capabilities are compared against `WP_User::allcaps` rather than `current_user_can()`: meta capabilities such as `edit_post` cannot resolve without an object and would otherwise false-negative every role. This is not theoretical — during testing, third-party plugins had injected `edit_post` into the `subscriber` role, which broke even legitimate subscriber promotion under a naive `current_user_can()` check. The ignored meta-cap list is filterable via `erp_role_comparison_ignored_caps`.
- **`erp_get_editable_roles()`** now filters through that check, which fixes the AJAX allow-list and the role dropdown in the UI from a single place.
- **`erp_crm_make_wp_user()`** validates the requested role at the sink as well, since it is public API called with a caller-supplied `$args['role']`. The validated role is also re-asserted after the `erp_crm_make_wpuser_args` filter so a filter cannot reintroduce a higher-privileged role.
- **People-meta copy loop** now skips `wp_capabilities`, `wp_user_level` and other protected user meta keys. That loop wrote arbitrary people-meta keys straight into user meta, which was a second escalation path via attacker-influenced key names.

### Regression coverage

`tests/pw/tests/api/security/crmRoleEscalation.api.spec.ts` drives the real `erp-crm-make-wp-user` admin-ajax endpoint as a low-privileged CRM agent — the attacker's actual entry point, rather than asserting on the PHP helpers in isolation. It covers:

- the agent cannot promote a contact to `editor` / `author` / `contributor` / `administrator`;
- a `subscriber` promotion still succeeds (the fix must not break the legitimate flow);
- the server-rendered role dropdown offers no role above the agent;
- an anonymous request is refused.

Every escalation case asserts both the response **and** that no WordPress user was created — a refusal that still leaves an account behind would not be a fix.

Supporting changes: a `crm_agent1` account provisioned as subscriber + `erp_crm_agent` (the reported attacker profile) via a new `ensureUserWithRoles()` helper that layers roles with `wp user add-role` instead of replacing them; and `CrmPage.insertContactRow()` now accepts `contact_owner`, which `insertPerson()` already supported — ownership is required because `erp_crm_edit_contact` maps to `do_not_allow` for an agent on contacts they do not own.

## Testing

**Red/green verified.** With the fix reverted in the working tree, the `editor`, `author`, `contributor` and dropdown cases all fail — the editor attempt returns `{"success":true}` and a real Editor account is created — while `subscriber` and the anonymous case stay green. `administrator` also stays green on the vulnerable code, since the old allow-list already stripped it. That failure signature matches the reported bug exactly. With the fix applied, all 7 pass.

Full run against wp-env (WP 6.x, PHP 8.2, lite):

| Suite | Result |
|---|---|
| `auth_setup` (incl. new CRM agent) | 10 passed |
| `tests/api/security` | 7 passed |
| `tests/api/crm` (regression) | 19 passed |

Also verified with WP-CLI against a live site, using a `subscriber` + `erp_crm_agent` account:

| Actor | Action | Before | After |
|---|---|---|---|
| CRM Agent | `erp_crm_make_wp_user(role=editor)` | Editor account created | `WP_Error` — "You are not allowed to create a user with the selected role"; no user created |
| CRM Agent | `erp_crm_make_wp_user(role=subscriber)` | created | still works, resulting role `subscriber` |
| CRM Agent | AJAX / dropdown allow-list | every role except `administrator` | only subscriber-level roles |
| Administrator | `erp_get_editable_roles()` | 30 roles, `editor` allowed | 30 roles, `editor` allowed (unchanged) |

`php -l` passes on both modified PHP files; `tsc --noEmit` and `eslint` pass on the test changes.

## Notes for reviewers

- HRM's `Employee::get_roles()` calls `erp_get_editable_roles()`, but discards it when `$include_erp_only` is true (the default), so that path is unaffected.
- `erp_crm_current_user_can_make_wp_user()` is deliberately left as-is: agents may still promote contacts, they are simply now limited to roles at or below their own privilege level. Sites that want to block agents entirely can still use the existing `erp_crm_agent_can_make_wp_user` filter.
- CI currently runs the Playwright suite only; `tests/api/security/` was an empty placeholder directory before this PR and now holds its first spec.
