### PR TITLE
fix(hrm): make leave policy REST endpoints write and read real columns

### DIFF
--- a/modules/hrm/includes/API/LeavePoliciesController.php
+++ b/modules/hrm/includes/API/LeavePoliciesController.php
@@ -3,6 +3,7 @@
 namespace WeDevs\ERP\HRM\API;
 
 use WeDevs\ERP\API\REST_Controller;
+use WeDevs\ERP\HRM\Models\Leave;
 use WP_Error;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -108,13 +109,23 @@ class LeavePoliciesController extends REST_Controller {
             'offset' => ( $request['per_page'] * ( $request['page'] - 1 ) ),
         ];
 
-        $items       = erp_hr_leave_get_policies( $args );
-        $total_items = erp_hr_count_leave_policies();
+        $policies    = erp_hr_leave_get_policies( $args );
+        $items       = ! empty( $policies['data'] ) ? $policies['data'] : [];
+        $total_items = isset( $policies['total'] ) ? (int) $policies['total'] : erp_hr_count_leave_policies();
 
         $formated_items = [];
 
         foreach ( $items as $item ) {
-            $data             = $this->prepare_item_for_response( $item, $request );
+            // erp_hr_leave_get_policies() returns display-formatted rows; reload the
+            // record so the response always describes the same fields as the single
+            // resource endpoints.
+            $policy = erp_hr_leave_get_policy( $item->id );
+
+            if ( empty( $policy ) ) {
+                continue;
+            }
+
+            $data             = $this->prepare_item_for_response( $policy, $request );
             $formated_items[] = $this->prepare_response_for_collection( $data );
         }
 
@@ -156,16 +167,61 @@ class LeavePoliciesController extends REST_Controller {
      * @return WP_Error|WP_REST_Request
      */
     public function create_policy( $request ) {
-        $item   = $this->prepare_item_for_database( $request );
-        $policy = erp_hr_leave_insert_policy( $item );
+        $item = $this->prepare_item_for_database( $request );
+
+        if ( is_wp_error( $item ) ) {
+            return $item;
+        }
+
+        $policy_id = erp_hr_leave_insert_policy( $item );
+
+        if ( is_wp_error( $policy_id ) ) {
+            return $this->to_rest_error( $policy_id );
+        }
+
+        $policy = erp_hr_leave_get_policy( $policy_id );
+
+        if ( empty( $policy ) ) {
+            return new WP_Error( 'rest_policy_not_created', __( 'The leave policy could not be created.', 'erp' ), [ 'status' => 500 ] );
+        }
 
         $request->set_param( 'context', 'edit' );
         $response = $this->prepare_item_for_response( $policy, $request );
         $response = rest_ensure_response( $response );
         $response->set_status( 201 );
-        $response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $id ) ) );
+        $response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $policy_id ) ) );
 
         return $response;
+    }
+
+    /**
+     * Convert a WP_Error coming from the data layer into one carrying an HTTP status.
+     *
+     * @since 1.17.9
+     *
+     * @param WP_Error $error
+     *
+     * @return WP_Error
+     */
+    protected function to_rest_error( $error ) {
+        $data = $error->get_error_data();
+
+        if ( isset( $data['status'] ) ) {
+            return $error;
+        }
+
+        $statuses = [
+            'no-permission'     => 403,
+            'exists'            => 409,
+            'no-leave-id'       => 400,
+            'no-financial-year' => 400,
+            'not_exists'        => 404,
+        ];
+
+        $code   = $error->get_error_code();
+        $status = isset( $statuses[ $code ] ) ? $statuses[ $code ] : 400;
+
+        return new WP_Error( $code, $error->get_error_message(), [ 'status' => $status ] );
     }
 
     /**
@@ -186,14 +242,29 @@ class LeavePoliciesController extends REST_Controller {
 
         $item = $this->prepare_item_for_database( $request );
 
+        if ( is_wp_error( $item ) ) {
+            return $item;
+        }
+
+        $item['id'] = $id;
+
         $policy_id = erp_hr_leave_insert_policy( $item );
-        $policy    = erp_hr_leave_get_policy( $policy_id );
+
+        if ( is_wp_error( $policy_id ) ) {
+            return $this->to_rest_error( $policy_id );
+        }
+
+        $policy = erp_hr_leave_get_policy( $policy_id );
+
+        if ( empty( $policy ) ) {
+            return new WP_Error( 'rest_policy_not_updated', __( 'The leave policy could not be updated.', 'erp' ), [ 'status' => 500 ] );
+        }
 
         $request->set_param( 'context', 'edit' );
         $response = $this->prepare_item_for_response( $policy, $request );
         $response = rest_ensure_response( $response );
-        $response->set_status( 201 );
-        $response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $id ) ) );
+        $response->set_status( 200 );
+        $response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $policy_id ) ) );
 
         return $response;
     }
@@ -223,16 +294,47 @@ class LeavePoliciesController extends REST_Controller {
     protected function prepare_item_for_database( $request ) {
         $prepared_item = [];
 
-        // required arguments.
-        if ( isset( $request['name'] ) ) {
-            $prepared_item['name'] = $request['name'];
+        $is_update = ! empty( $request['id'] );
+
+        // Financial year — fall back to the one covering today when omitted.
+        // Resolved before the leave type so a missing financial year cannot leave
+        // a newly created leave type behind.
+        $f_year = isset( $request['f_year'] ) ? absint( $request['f_year'] ) : 0;
+
+        if ( ! $f_year && ! $is_update ) {
+            $current_f_year = erp_hr_get_financial_year_from_date();
+
+            if ( empty( $current_f_year ) ) {
+                return new WP_Error(
+                    'rest_policy_no_financial_year',
+                    __( 'No financial year is configured for the current date. Pass a f_year or create a financial year first.', 'erp' ),
+                    [ 'status' => 400 ]
+                );
+            }
+
+            $f_year = (int) $current_f_year->id;
+        }
+
+        if ( $f_year ) {
+            $prepared_item['f_year'] = $f_year;
+        }
+
+        // Resolve the leave type. `leave_id` wins over `name` when both are given.
+        $leave_id = $this->resolve_leave_id( $request );
+
+        if ( is_wp_error( $leave_id ) ) {
+            return $leave_id;
+        }
+
+        if ( $leave_id ) {
+            $prepared_item['leave_id'] = $leave_id;
         }
 
         if ( isset( $request['days'] ) ) {
-            $prepared_item['value'] = absint( $request['days'] );
+            $prepared_item['days'] = absint( $request['days'] );
         }
 
-        $prepared_item['color'] = isset( $request['color'] ) ? $request['color'] : '#fafafa';
+        $prepared_item['color'] = isset( $request['color'] ) ? sanitize_text_field( $request['color'] ) : '#fafafa';
 
         // optional arguments.
         if ( isset( $request['id'] ) ) {
@@ -240,43 +342,94 @@ class LeavePoliciesController extends REST_Controller {
         }
 
         if ( isset( $request['department'] ) ) {
-            $prepared_item['department'] = absint( $request['department'] );
+            $prepared_item['department_id'] = absint( $request['department'] );
         }
 
         if ( isset( $request['designation'] ) ) {
-            $prepared_item['designation'] = absint( $request['designation'] );
-        }
-
-        if ( isset( $request['gender'] ) ) {
-            $prepared_item['gender'] = $request['gender'];
-        }
-
-        if ( isset( $request['marital'] ) ) {
-            $prepared_item['marital'] = $request['marital'];
-        }
-
-        if ( isset( $request['activate'] ) ) {
-            $activate_types            = array_flip( $this->activate_types );
-            $prepared_item['activate'] = $activate_types[ $request['activate'] ];
-        }
-
-        if ( isset( $request['execute_day'] ) ) {
-            $prepared_item['execute_day'] = absint( $request['execute_day'] );
-        }
-
-        if ( isset( $request['effective_date'] ) ) {
-            $prepared_item['effective_date'] = gmdate( 'Y-m-d', strtotime( $request['effective_date'] ) );
+            $prepared_item['designation_id'] = absint( $request['designation'] );
         }
 
         if ( isset( $request['location'] ) ) {
-            $prepared_item['location'] = absint( $request['location'] );
+            $prepared_item['location_id'] = absint( $request['location'] );
+        }
+
+        if ( isset( $request['employee_type'] ) ) {
+            $prepared_item['employee_type'] = sanitize_text_field( $request['employee_type'] );
+        }
+
+        if ( isset( $request['gender'] ) ) {
+            $prepared_item['gender'] = sanitize_text_field( $request['gender'] );
+        }
+
+        if ( isset( $request['marital'] ) ) {
+            $prepared_item['marital'] = sanitize_text_field( $request['marital'] );
+        }
+
+        if ( isset( $request['applicable_from'] ) ) {
+            $prepared_item['applicable_from'] = absint( $request['applicable_from'] );
+        }
+
+        if ( isset( $request['apply_for_new_users'] ) ) {
+            $prepared_item['apply_for_new_users'] = ! empty( $request['apply_for_new_users'] ) ? 1 : 0;
         }
 
         if ( isset( $request['description'] ) ) {
-            $prepared_item['description'] = $request['description'];
+            $prepared_item['description'] = sanitize_text_field( $request['description'] );
         }
 
         return $prepared_item;
+    }
+
+    /**
+     * Resolve the leave type id a policy belongs to.
+     *
+     * Accepts an explicit `leave_id`, or a leave type `name` which is matched
+     * against the existing types and created when it does not exist yet.
+     *
+     * @since 1.17.9
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return int|WP_Error leave type id, 0 when neither field was sent
+     */
+    protected function resolve_leave_id( $request ) {
+        if ( ! empty( $request['leave_id'] ) ) {
+            $leave_id = absint( $request['leave_id'] );
+            $leave    = Leave::find( $leave_id );
+
+            if ( ! $leave ) {
+                return new WP_Error( 'rest_policy_invalid_leave_id', __( 'Invalid leave type id.', 'erp' ), [ 'status' => 400 ] );
+            }
+
+            return $leave_id;
+        }
+
+        if ( ! isset( $request['name'] ) ) {
+            return 0;
+        }
+
+        $name = sanitize_text_field( $request['name'] );
+
+        if ( '' === $name ) {
+            return new WP_Error( 'rest_policy_invalid_name', __( 'Name cannot be empty.', 'erp' ), [ 'status' => 400 ] );
+        }
+
+        $leave = Leave::where( 'name', $name )->first();
+
+        if ( $leave ) {
+            return (int) $leave->id;
+        }
+
+        $leave_id = erp_hr_insert_leave_policy_name( [
+            'name'        => $name,
+            'description' => isset( $request['description'] ) ? sanitize_text_field( $request['description'] ) : '',
+        ] );
+
+        if ( is_wp_error( $leave_id ) ) {
+            return $this->to_rest_error( $leave_id );
+        }
+
+        return (int) $leave_id;
     }
 
     /**
@@ -289,18 +442,27 @@ class LeavePoliciesController extends REST_Controller {
      * @return WP_REST_Response $response response data
      */
     public function prepare_item_for_response( $item, $request, $additional_fields = [] ) {
+        $name = isset( $item->name ) ? $item->name : null;
+
+        if ( null === $name && ! empty( $item->leave_id ) ) {
+            $leave = Leave::find( $item->leave_id );
+            $name  = $leave ? $leave->name : null;
+        }
+
         $data = [
-            'id'             => (int) $item->id,
-            'name'           => $item->name,
-            'days'           => (int) $item->value,
-            'color'          => $item->color,
-            'gender'         => ( $item->gender != -1 ) ? $item->gender : null,
-            'marital'        => ( $item->marital != -1 ) ? $item->marital : null,
-            'activate'       => $this->activate_types[ $item->activate ],
-            'execute_day'    => (int) $item->execute_day,
-            'effective_date' => gmdate( 'Y-m-d', strtotime( $item->effective_date ) ),
-            'location'       => ( $item->location != -1 ) ? $item->location : null,
-            'description'    => $item->description,
+            'id'                  => (int) $item->id,
+            'leave_id'            => (int) $item->leave_id,
+            'name'                => $name,
+            'days'                => (int) $item->days,
+            'color'               => $item->color,
+            'f_year'              => isset( $item->f_year ) ? (int) $item->f_year : null,
+            'employee_type'       => ( '-1' != $item->employee_type ) ? $item->employee_type : null,
+            'gender'              => ( '-1' != $item->gender ) ? $item->gender : null,
+            'marital'             => ( '-1' != $item->marital ) ? $item->marital : null,
+            'location'            => ( '-1' != $item->location_id ) ? (int) $item->location_id : null,
+            'applicable_from'     => (int) $item->applicable_from_days,
+            'apply_for_new_users' => (bool) $item->apply_for_new_users,
+            'description'         => $item->description,
         ];
 
         if ( isset( $request['include'] ) ) {
@@ -309,7 +471,7 @@ class LeavePoliciesController extends REST_Controller {
             if ( in_array( 'department', $include_params ) ) {
                 $departments_controller = new DepartmentsController();
 
-                $department_id      = (int) $item->department;
+                $department_id      = (int) $item->department_id;
                 $data['department'] = null;
 
                 if ( $department_id ) {
@@ -321,7 +483,7 @@ class LeavePoliciesController extends REST_Controller {
             if ( in_array( 'designation', $include_params ) ) {
                 $designations_controller = new DesignationsController();
 
-                $designation_id      = (int) $item->designation;
+                $designation_id      = (int) $item->designation_id;
                 $data['designation'] = null;
 
                 if ( $designation_id ) {
@@ -367,6 +529,11 @@ class LeavePoliciesController extends REST_Controller {
                     ],
                     'required'    => true,
                 ],
+                'leave_id'    => [
+                    'description' => __( 'Leave type id the policy belongs to. Resolved from name when omitted.', 'erp' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'embed', 'view', 'edit' ],
+                ],
                 'days'        => [
                     'description' => __( 'Days for the resource.', 'erp' ),
                     'type'        => 'integer',
@@ -380,6 +547,11 @@ class LeavePoliciesController extends REST_Controller {
                     'arg_options' => [
                         'sanitize_callback' => 'sanitize_text_field',
                     ],
+                ],
+                'f_year'      => [
+                    'description' => __( 'Financial year id. Defaults to the year covering the current date.', 'erp' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'embed', 'view', 'edit' ],
                 ],
             ],
         ];

--- a/modules/hrm/includes/functions-leave.php
+++ b/modules/hrm/includes/functions-leave.php
@@ -187,10 +187,31 @@ function erp_hr_leave_insert_policy( $args = [] ) {
     }
 
     $defaults = [
-        'id' => null,
+        'id'                  => null,
+        'leave_id'            => 0,
+        'employee_type'       => '-1',
+        'department_id'       => '-1',
+        'designation_id'      => '-1',
+        'location_id'         => '-1',
+        'gender'              => '-1',
+        'marital'             => '-1',
+        'f_year'              => 0,
+        'description'         => '',
+        'days'                => 0,
+        'color'               => '',
+        'applicable_from'     => 0,
+        'apply_for_new_users' => 0,
     ];
 
     $args = wp_parse_args( $args, $defaults );
+
+    if ( empty( $args['id'] ) && empty( $args['leave_id'] ) ) {
+        return new WP_Error( 'no-leave-id', esc_html__( 'A leave type is required to create a leave policy.', 'erp' ), [ 'status' => 400 ] );
+    }
+
+    if ( empty( $args['id'] ) && empty( $args['f_year'] ) ) {
+        return new WP_Error( 'no-financial-year', esc_html__( 'A financial year is required to create a leave policy.', 'erp' ), [ 'status' => 400 ] );
+    }
 
     $common = [
         'leave_id'       => $args['leave_id'],


### PR DESCRIPTION
Fixes wp-erp/erp-pro#951.

Thanks to QA for the report — the reproduction steps, the DB row count and the `create_policy()` root-cause pointer were exact, and made this a quick one to confirm. QA also correctly flagged the undefined `$id` on the `Location` line. Filed on `erp-pro`, but the code lives here in the free plugin.

## What was wrong

`LeavePoliciesController` was never updated for the 1.6.0 leave schema. It mapped request fields onto columns that no longer exist (`value`, `activate`, `execute_day`, `effective_date`, `location`) and never sent the ones that do (`leave_id`, `f_year`, `days`).

So the insert died at the database with `Column 'leave_id' cannot be null`, emitted ~25 PHP 8 warnings, and still answered `201 Created` with an empty record while writing zero rows — exactly as reported:

```json
{"id":0,"name":null,"days":0,"color":null,"gender":null,"marital":null,"activate":null,
 "execute_day":0,"effective_date":"1970-01-01","location":null,"description":null}
```

Two things beyond the report:

- **`GET` was broken the same way.** `erp_hr_leave_get_policies()` returns `['data' => ..., 'total' => ...]`, but the controller iterated the wrapper, so the list endpoint also returned null-filled records.
- **`PUT` never updated anything.** `update_policy()` dropped the route `id` before calling the helper, so every update attempted an insert.

## Changes

**`create_policy()`** — check `is_wp_error()` on the insert, reload the saved record, return `201` only when a row was really written. `Location` header now uses the real policy id instead of the undefined `$id`.

**`prepare_item_for_database()`** — map to the columns that actually exist. Resolve `leave_id` from an explicit `leave_id`, or by matching / creating the leave type named by `name`. Default `f_year` to the financial year covering today, `400` when none is configured. The financial year is validated *before* the leave type, so a rejected request cannot leave a stray leave type behind.

**`prepare_item_for_response()`** — read the real columns. `$item->department` / `$item->designation` are relation objects, so read `department_id` / `designation_id` rather than int-casting the relation.

**`get_policies()`** — unwrap `['data']`, use the query's own total.

**`update_policy()`** — pass the route id through, and answer `200` instead of `201`.

Data-layer errors now carry an HTTP status: `no-permission` → 403, `exists` → 409, missing leave type / financial year → 400.

**`erp_hr_leave_insert_policy()`** — defaulted only `id` while reading 13 other keys, so every caller risked PHP 8 undefined-key warnings. Added the full defaults and guards for the two genuinely required fields.

## Verification

| Case | Before | After |
|---|---|---|
| Create | `201`, 0 rows written | `201`, row written, real id |
| Duplicate create | `201` | `409` `Policy already exists.` |
| Create, no financial year | `201` | `400` with a message naming the requirement |
| `GET` list | null-filled records | correct records |
| `GET` one / `GET` 99999 | null-filled | `200` / `404` |
| `PUT` | `201`, nothing updated | `200`, updated |
| Subscriber create | — | `403` |

This satisfies the issue's expected result: the policy is created and the body carries the real `id`, `name` and `days`, or the request is rejected with a `4xx` naming the missing requirement. No create that writes nothing answers `201` any more.

No PHP warnings remain from either file. The admin form path (`FormHandler`) and the CLI seeder were retested and are unchanged. PHPCS reports the same six sniff categories as the pre-change baseline — no new class of violation; the file's short-array style is pre-existing and there is no project ruleset.

## Notes

- `days=0` / negative-day coercion is **ERP-056**, a separate defect QA raised in the same area — not touched here.
- The `wpdb::prepare` "unsupported value type (array)" notice from `erp_hr_get_financial_year_from_date()` predates this (2023) and is unrelated.
- The existing Playwright specs tolerate the old broken behaviour — `advancedLeave.api.spec.ts` even cites `create_policy:166` as a known bug — so they pass unchanged. Worth a follow-up to tighten them into asserting the correct contract now that it holds.
