### PR TITLE
fix(hrm): scope employee REST reads to object-level capability

### DIFF
--- a/modules/hrm/includes/API/EmployeesController.php
+++ b/modules/hrm/includes/API/EmployeesController.php
@@ -72,11 +72,11 @@ class EmployeesController extends REST_Controller {
                     'context' => $this->get_context_param( [ 'default' => 'view' ] ),
                 ],
                 'permission_callback' => function ( $request ) {
-                    $user_id = (int) $request['user_id'];
-                    $current_user_id = get_current_user_id();
-
-                    // Allow users to view their own profile or if they have erp_list_employee capability
-                    return ( $user_id === $current_user_id ) || current_user_can( 'erp_list_employee' );
+                    // Object-scoped: the employee themselves or an HR manager.
+                    // `erp_list_employee` is a blanket list-screen cap held by every
+                    // employee and is NOT scoped to the requested id, so using it here
+                    // let any employee read any other employee's record (incl. pay rate).
+                    return current_user_can( 'erp_view_employee', (int) $request['user_id'] );
                 },
             ],
             [
@@ -1775,6 +1775,31 @@ class EmployeesController extends REST_Controller {
             return !is_numeric($key);
         }, ARRAY_FILTER_USE_KEY);
 
+        // Field-level privacy (mirrors V2 EmployeesController::get_item): pay,
+        // personal, address and contact details are visible only to the employee
+        // themselves or an HR manager. The list route (`erp_view_list`) is held by
+        // every employee, so without this a peer row would leak pay_rate/pay_type
+        // and PII for the whole roster in a single call.
+        $target_user_id  = (int) $item->get_user_id();
+        $can_see_private = ( get_current_user_id() === $target_user_id )
+            || current_user_can( 'erp_edit_employee', $target_user_id );
+
+        if ( ! $can_see_private ) {
+            $private_fields = [
+                'pay_rate', 'pay_type',
+                'date_of_birth', 'gender', 'marital_status', 'blood_group', 'nationality',
+                'driving_license', 'hobbies', 'father_name', 'mother_name', 'spouse_name',
+                'street_1', 'street_2', 'city', 'state', 'country', 'postal_code',
+                'description', 'work_phone', 'phone', 'mobile', 'other_email', 'user_url',
+            ];
+
+            foreach ( $private_fields as $private_field ) {
+                if ( array_key_exists( $private_field, $data ) ) {
+                    $data[ $private_field ] = '';
+                }
+            }
+        }
+
         // Always add human-readable labels for enum fields
         // $data = $this->add_enum_labels($data, $item);
 
@@ -1806,8 +1831,10 @@ class EmployeesController extends REST_Controller {
                 $data['roles'] = $item->get_roles();
             }
 
-            // Include job histories if requested
-            if ( in_array( 'job_histories', $include_params ) || in_array( 'histories', $include_params ) ) {
+            // Include job histories if requested. Compensation history carries pay,
+            // so this is gated to the employee themselves or an HR manager.
+            if ( $can_see_private
+                && ( in_array( 'job_histories', $include_params ) || in_array( 'histories', $include_params ) ) ) {
                 $histories = $item->get_job_histories( 'all' );
 
                 // Convert IDs to names and add reporting_to_full_name for job histories


### PR DESCRIPTION
## Problem

The v1 HRM employee REST routes expose employee pay rate + PII to any logged-in employee.

**By-id read** — `GET /erp/v1/hrm/employees/{id}` gated on `current_user_can( 'erp_list_employee' )`. `erp_list_employee` is a blanket list-screen cap held by every `employee`-role user, and its `map_meta_cap` case is not scoped to the requested id, so the check is `true` for any employee for any id. With `?include=job_histories`, the `compensation_history` in the response leaks the target's pay even when the base `pay_rate` field is unset.

**List read** — `GET /erp/v1/hrm/employees` gated on `erp_view_list` (also held by every employee). Rows go through the same `prepare_item_for_response()`, which merges `$item->get_data()` → each row carries `pay_rate`, `pay_type` plus DOB / address / phone / next-of-kin names.

The v2 controller already handles this correctly in `get_item()`.

## Changes

1. **By-id route** → `current_user_can( 'erp_view_employee', (int) $request['user_id'] )`. `erp_view_employee` is object-scoped (self OR HR manager) via `erp_hr_map_meta_caps()`, matching the sibling sub-resource routes on this controller.
2. **`prepare_item_for_response()`** → strip `pay_rate`/`pay_type` + personal/address/contact fields for any viewer who is neither the record owner nor an HR manager. Protects the list route; defense-in-depth for the by-id route. Mirrors `V2 EmployeesController::get_item()`.
3. **`job_histories` include** → gated on the same `$can_see_private` (its `compensation_history` carries pay).

## Local validation

Probed via `rest_do_request()` as a plain `employee`-role user (has `erp_list_employee`, not a manager) and as an HR manager, before vs after applying this patch. Read-only, no data writes.

| case | before | after |
|---|---|---|
| employee → peer, `?include=job_histories` | **200, pay leaked** | **403** |
| employee → peer pay via list | 200 (no leak on this dataset) | 200, stripped |
| employee → **own** record | 200, own pay visible | 200, own pay visible |
| HR manager → peer | 200, pay visible | 200, pay visible |
| HR manager → list | 200, pay visible | 200, pay visible |

Result: the cross-employee leak is closed, while an employee still sees their **own** record and an HR manager still sees **everyone** — no legitimate access is broken.

## Notes

- Supersedes #1633 (keeps its by-id fix, adds the list-route protection it was missing).
- `erp_hrm_hide_pay_rate` is still enforced only on the frontend (blur); a follow-up could strip pay server-side when the option is `yes`.
- Behavior change (same as #1633): a plain reporting manager who is not an HR manager loses read on a report through this route. If “my team” relies on it, add a `reporting_to` branch to the `erp_view_employee` case in `erp_hr_map_meta_caps()`.

Closes wp-erp/erp-pro#986
